### PR TITLE
Add TextProviderBuilder to isolate text and children properties

### DIFF
--- a/src/platform/lumin-runtime/elements/builders/text-container-builder.js
+++ b/src/platform/lumin-runtime/elements/builders/text-container-builder.js
@@ -1,44 +1,14 @@
 // Copyright (c) 2019 Magic Leap, Inc. All Rights Reserved
 
-import { ui } from 'lumin';
-
-import { UiNodeBuilder } from './ui-node-builder.js';
 import { ArrayProperty } from '../properties/array-property.js';
 import { PrimitiveTypeProperty } from '../properties/primitive-type-property.js';
-import { TextChildrenProperty } from '../properties/text-children-property.js';
+import { TextProviderBuilder } from './text-provider-builder';
 
-export class TextContainerBuilder extends UiNodeBuilder {
+export class TextContainerBuilder extends TextProviderBuilder {
     constructor(){
         super();
 
-        this._propertyDescriptors['children'] = new TextChildrenProperty('children', 'setText', false);
-
-        this._propertyDescriptors['text'] = new PrimitiveTypeProperty('text', 'setText', false, 'string');
         this._propertyDescriptors['textColor'] = new ArrayProperty('textColor', 'setTextColor', true, 'vec4');
         this._propertyDescriptors['textSize'] = new PrimitiveTypeProperty('textSize', 'setTextSize', true, 'number');
-    }
-
-    setText(element, oldProperties, newProperties) {
-        let text = newProperties.text;
-
-        if (text === undefined) {
-            text = this._getText(newProperties.children);
-        }
-
-        element.setText(text);
-    }
-
-    _getText(children) {
-        let text;
-
-        if (Array.isArray(children)) {
-            text = children.join('');
-        } else if (typeof children === 'number') {
-            text = children.toString();
-        } else {
-            text = children;
-        }
-
-        return text;
     }
 }

--- a/src/platform/lumin-runtime/elements/builders/text-provider-builder.js
+++ b/src/platform/lumin-runtime/elements/builders/text-provider-builder.js
@@ -1,0 +1,38 @@
+// Copyright (c) 2019 Magic Leap, Inc. All Rights Reserved
+
+import { UiNodeBuilder } from './ui-node-builder.js';
+import { PrimitiveTypeProperty } from '../properties/primitive-type-property.js';
+import { TextChildrenProperty } from '../properties/text-children-property.js';
+
+export class TextProviderBuilder extends UiNodeBuilder {
+    constructor(){
+        super();
+
+        this._propertyDescriptors['children'] = new TextChildrenProperty('children', 'setText', false);
+        this._propertyDescriptors['text'] = new PrimitiveTypeProperty('text', 'setText', false, 'string');
+    }
+
+    setText(element, oldProperties, newProperties) {
+        let text = newProperties.text;
+
+        if (text === undefined) {
+            text = this._getText(newProperties.children);
+        }
+
+        element.setText(text);
+    }
+
+    _getText(children) {
+        let text;
+
+        if (Array.isArray(children)) {
+            text = children.join('');
+        } else if (typeof children === 'number') {
+            text = children.toString();
+        } else {
+            text = children;
+        }
+
+        return text;
+    }
+}


### PR DESCRIPTION
Extract `text` and `children` properties management in separate builder. The need is for base class which will provide `text` and `children` set and get functionality.
