### PR TITLE
Add missing reference for PrimitiveTypeProperty

### DIFF
--- a/src/platform/lumin-runtime/elements/builders/dialog-builder.js
+++ b/src/platform/lumin-runtime/elements/builders/dialog-builder.js
@@ -5,7 +5,7 @@ import { ui } from 'lumin';
 import { TextProviderBuilder } from './text-provider-builder.js';
 import { EnumProperty } from '../properties/enum-property.js';
 import { PropertyDescriptor } from '../properties/property-descriptor.js';
-
+import { PrimitiveTypeProperty } from '../properties/primitive-type-property.js';
 
 import { DialogType } from '../../types/dialog-type.js';
 import { DialogLayout } from '../../types/dialog-layout.js';


### PR DESCRIPTION
Add missing reference for PrimitiveTypeProperty to DialogBuilder.js file
