### PR TITLE
Remove the use of MxsListViewItem and MxsScrollBar

### DIFF
--- a/src/platform/lumin-runtime/elements/builders/list-view-builder.js
+++ b/src/platform/lumin-runtime/elements/builders/list-view-builder.js
@@ -9,112 +9,113 @@ import { EnumProperty } from '../properties/enum-property.js';
 import { PrimitiveTypeProperty } from '../properties/primitive-type-property.js';
 import { PropertyDescriptor } from '../properties/property-descriptor.js';
 
-import { Alignment } from '../../types/alignment.js'
+import { Alignment } from '../../types/alignment.js';
 import { CursorEdgeScrollMode } from '../../types/cursor-edge-scroll-mode.js';
 import { Orientation } from '../../types/orientation.js';
 import { ScrollBarVisibility } from '../../types/scroll-bar-visibility.js';
 
 export class ListViewBuilder extends UiNodeBuilder {
-    constructor(){
-        super();
+  constructor () {
+    super();
 
-        this._propertyDescriptors['cursorEdgeScrollMode'] = new EnumProperty('cursorEdgeScrollMode', 'setCursorEdgeScrollMode', false, CursorEdgeScrollMode, 'CursorEdgeScrollMode');
-        this._propertyDescriptors['defaultItemAlignment'] = new EnumProperty('defaultItemAlignment', 'setDefaultItemAlignment', false, Alignment, 'Alignment');
-        this._propertyDescriptors['defaultItemPadding'] = new ArrayProperty('defaultItemPadding', 'setDefaultItemPadding', true, 'vec4');
-        this._propertyDescriptors['orientation'] = new EnumProperty('orientation', 'setOrientation', false, Orientation, 'Orientation');
+    this._propertyDescriptors['cursorEdgeScrollMode'] = new EnumProperty('cursorEdgeScrollMode', 'setCursorEdgeScrollMode', false, CursorEdgeScrollMode, 'CursorEdgeScrollMode');
+    this._propertyDescriptors['defaultItemAlignment'] = new EnumProperty('defaultItemAlignment', 'setDefaultItemAlignment', false, Alignment, 'Alignment');
+    this._propertyDescriptors['defaultItemPadding'] = new ArrayProperty('defaultItemPadding', 'setDefaultItemPadding', true, 'vec4');
+    this._propertyDescriptors['orientation'] = new EnumProperty('orientation', 'setOrientation', false, Orientation, 'Orientation');
 
-        // ScrollBar
+    // ScrollBar
 
-        this._propertyDescriptors['scrollBarVisibility'] = new EnumProperty('scrollBarVisibility', 'setScrollBarVisibilityMode', false, ScrollBarVisibility, 'ScrollBarVisibility');
-        this._propertyDescriptors['scrollingEnabled'] = new PrimitiveTypeProperty('scrollingEnabled', 'setScrollingEnabled', true, 'boolean');
-        this._propertyDescriptors['scrollSpeed'] = new PrimitiveTypeProperty('scrollSpeed', 'setScrollSpeed', true, 'number');
-        this._propertyDescriptors['scrollValue'] = new PrimitiveTypeProperty('scrollValue', 'setScrollValue', true, 'number');
-        this._propertyDescriptors['scrollToItem'] = new PrimitiveTypeProperty('scrollToItem', 'scrollToItem', true, 'number');
-        this._propertyDescriptors['skipInvisibleItems'] = new PrimitiveTypeProperty('skipInvisibleItems', 'setSkipInvisibleItems', true, 'boolean');
+    this._propertyDescriptors['scrollBarVisibility'] = new EnumProperty('scrollBarVisibility', 'setScrollBarVisibilityMode', false, ScrollBarVisibility, 'ScrollBarVisibility');
+    this._propertyDescriptors['scrollingEnabled'] = new PrimitiveTypeProperty('scrollingEnabled', 'setScrollingEnabled', true, 'boolean');
+    this._propertyDescriptors['scrollSpeed'] = new PrimitiveTypeProperty('scrollSpeed', 'setScrollSpeed', true, 'number');
+    this._propertyDescriptors['scrollValue'] = new PrimitiveTypeProperty('scrollValue', 'setScrollValue', true, 'number');
+    this._propertyDescriptors['scrollToItem'] = new PrimitiveTypeProperty('scrollToItem', 'scrollToItem', true, 'number');
+    this._propertyDescriptors['skipInvisibleItems'] = new PrimitiveTypeProperty('skipInvisibleItems', 'setSkipInvisibleItems', true, 'boolean');
 
-        // itemAlignment
-        const itemAlignmentProperties = [
-            new PrimitiveTypeProperty('index', undefined, undefined, 'number'),
-            new EnumProperty('alignment', undefined, undefined, Alignment, 'Alignment')
-        ];
+    // itemAlignment
+    const itemAlignmentProperties = [
+      new PrimitiveTypeProperty('index', undefined, undefined, 'number'),
+      new EnumProperty('alignment', undefined, undefined, Alignment, 'Alignment')
+    ];
 
-        this._propertyDescriptors['itemAlignment'] = new ClassProperty('itemAlignment', 'setItemAlignment', false, itemAlignmentProperties);
+    this._propertyDescriptors['itemAlignment'] = new ClassProperty('itemAlignment', 'setItemAlignment', false, itemAlignmentProperties);
 
-        // itemPadding
-        const itemPaddingProperties = [
-            new PrimitiveTypeProperty('index', undefined, undefined, 'number'),
-            new ArrayProperty('padding', undefined, undefined, 'vec4')
-        ];
+    // itemPadding
+    const itemPaddingProperties = [
+      new PrimitiveTypeProperty('index', undefined, undefined, 'number'),
+      new ArrayProperty('padding', undefined, undefined, 'vec4')
+    ];
 
-        this._propertyDescriptors['itemPadding'] = new ClassProperty('itemPadding', 'setItemPadding', false, itemPaddingProperties);
+    this._propertyDescriptors['itemPadding'] = new ClassProperty('itemPadding', 'setItemPadding', false, itemPaddingProperties);
+  }
+
+  create (prism, properties) {
+    this.throwIfInvalidPrism(prism);
+
+    this.validate(undefined, undefined, properties);
+
+    const width = this.getPropertyValue('width', 0, properties);
+    const height = this.getPropertyValue('height', 0, properties);
+
+    const element = ui.UiListView.Create(prism, width, height);
+
+    const unapplied = this.excludeProperties(properties, ['width', 'height']);
+
+    this.apply(element, undefined, unapplied);
+
+    return element;
+  }
+
+  validate (element, oldProperties, newProperties) {
+    super.validate(element, oldProperties, newProperties);
+
+    this._validateSize(newProperties);
+  }
+
+  setCursorEdgeScrollMode (element, oldProperties, newProperties) {
+    element.setCursorEdgeScrollMode(CursorEdgeScrollMode[newProperties.cursorEdgeScrollMode]);
+  }
+
+  setDefaultItemAlignment (element, oldProperties, newProperties) {
+    element.setDefaultItemAlignment(Alignment[newProperties.defaultItemAlignment]);
+  }
+
+  setOrientation (element, oldProperties, newProperties) {
+    element.setOrientation(Orientation[newProperties.orientation]);
+  }
+
+  setScrollBarVisibilityMode (element, oldProperties, newProperties) {
+    element.setScrollBarVisibilityMode(ScrollBarVisibility[newProperties.scrollBarVisibility]);
+  }
+
+  setItemAlignment (element, oldProperties, newProperties) {
+    const { index, alignment } = newProperties.itemAlignment;
+    element.setItemAlignment(index, Alignment[alignment]);
+  }
+
+  setItemPadding (element, oldProperties, newProperties) {
+    const { index, padding } = newProperties.itemPadding;
+    element.setItemPadding(index, padding);
+  }
+
+  _validateSize (properties) {
+    PropertyDescriptor.throwIfNotTypeOf(properties.height, 'number');
+    PropertyDescriptor.throwIfNotTypeOf(properties.width, 'number');
+  }
+
+  _setSize (element, properties) {
+    let { height, width } = properties;
+
+    if (width || height) {
+      if (width === undefined) {
+        width = element.getSize()[0];
+      }
+
+      if (height === undefined) {
+        height = element.getSize()[1];
+      }
+
+      element.setSize([height, width]);
     }
-
-    create(prism, properties) {
-        this.throwIfInvalidPrism(prism);
-
-        this.validate(undefined, undefined, properties);
-
-        const { width, height } = properties;
-
-        const element = ui.UiListView.Create(prism, width, height);
-
-        const unapplied = this.excludeProperties(properties, ['width', 'height']);
-
-        this.apply(element, undefined, unapplied);
-
-        return element;
-    }
-
-    validate(element, oldProperties, newProperties) {
-        super.validate(element, oldProperties, newProperties);
-
-        this._validateSize(newProperties);
-    }
-
-    setCursorEdgeScrollMode(element, oldProperties, newProperties) {
-        element.setCursorEdgeScrollMode(CursorEdgeScrollMode[newProperties.cursorEdgeScrollMode]);
-    }
-
-    setDefaultItemAlignment(element, oldProperties, newProperties) {
-        element.setDefaultItemAlignment(Alignment[newProperties.defaultItemAlignment]);
-    }
-
-    setOrientation(element, oldProperties, newProperties) {
-        element.setOrientation(Orientation[newProperties.orientation]);
-    }
-
-    setScrollBarVisibilityMode(element, oldProperties, newProperties) {
-        element.setScrollBarVisibilityMode(ScrollBarVisibility[newProperties.scrollBarVisibility])
-    }
-
-    setItemAlignment(element, oldProperties, newProperties) {
-        const { index, alignment } = newProperties.itemAlignment;
-        element.setItemAlignment(index, Alignment[alignment]);
-    }
-
-    setItemPadding(element, oldProperties, newProperties) {
-        const { index, padding } = newProperties.itemPadding;
-        element.setItemPadding(index, padding);
-    }
-
-    _validateSize(properties) {
-        PropertyDescriptor.throwIfNotTypeOf(properties.height, 'number');
-        PropertyDescriptor.throwIfNotTypeOf(properties.width, 'number');
-    }
-
-    _setSize(element, properties) {
-        const { height, width } = properties;
-
-        if (width || height) {
-            if (width === undefined) {
-                width = element.getSize()[0];
-            }
-
-            if (height === undefined) {
-                height = element.getSize()[1];
-            }
-
-            element.setSize([height, width]);
-        }
-    }
+  }
 }

--- a/src/platform/lumin-runtime/elements/builders/list-view-item-builder.js
+++ b/src/platform/lumin-runtime/elements/builders/list-view-item-builder.js
@@ -8,39 +8,51 @@ import { EnumProperty } from '../properties/enum-property.js';
 
 import { Alignment } from '../../types/alignment.js';
 
-import { MxsListViewItem } from '../mxs-list-view-item.js';
-
 export class ListViewItemBuilder extends UiNodeBuilder {
-    constructor(){
-        super();
+  constructor () {
+    super();
 
-        this._propertyDescriptors['backgroundColor'] = new ArrayProperty('backgroundColor', 'setBackgroundColor', true, 'vec3');
+    this._propertyDescriptors['backgroundColor'] = new ArrayProperty('backgroundColor', 'setBackgroundColor', true, 'vec3');
 
-        this._propertyDescriptors['padding'] = new ArrayProperty('padding', 'setPadding', false, 'vec4');
-        this._propertyDescriptors['itemAlignment'] = new EnumProperty('itemAlignment', 'setItemAlignment', false, Alignment, 'Alignment');
+    this._propertyDescriptors['padding'] = new ArrayProperty('padding', 'setPadding', false, 'vec4');
+    this._propertyDescriptors['itemAlignment'] = new EnumProperty('itemAlignment', 'setItemAlignment', false, Alignment, 'Alignment');
+  }
+
+  create (prism, properties) {
+    this.throwIfInvalidPrism(prism);
+
+    const element = ui.UiListViewItem.Create(prism);
+
+    Object.defineProperty(element, 'Padding', {
+      enumerable: true,
+      writable: true,
+      configurable: false,
+      value: [0, 0, 0, 0]
+    });
+
+    Object.defineProperty(element, 'ItemAlignment', {
+      enumerable: true,
+      writable: true,
+      configurable: false,
+      value: ui.Alignment.CENTER_CENTER
+    });
+
+    this.update(element, undefined, properties);
+
+    return element;
+  }
+
+  setPadding (element, oldProperties, newProperties) {
+    const padding = newProperties.padding;
+    if (padding !== undefined) {
+      element.Padding = padding;
     }
+  }
 
-    create(prism, properties) {
-        this.throwIfInvalidPrism(prism);
-
-        const element = MxsListViewItem.Create(prism);
-
-        this.update(element, undefined, properties);
-
-        return element;
+  setItemAlignment (element, oldProperties, newProperties) {
+    const itemAlignment = newProperties.itemAlignment;
+    if (itemAlignment !== undefined) {
+      element.ItemAlignment = Alignment[itemAlignment];
     }
-
-    setPadding(element, oldProperties, newProperties) {
-        const padding = newProperties.padding
-        if (padding !== undefined) {
-            element.Padding = padding;
-        }
-    }
-
-    setItemAlignment(element, oldProperties, newProperties) {
-        const itemAlignment = newProperties.itemAlignment;
-        if (itemAlignment !== undefined) {
-            element.ItemAlignment = Alignment[itemAlignment];
-        }
-    }
+  }
 }

--- a/src/platform/lumin-runtime/elements/builders/scroll-bar-builder.js
+++ b/src/platform/lumin-runtime/elements/builders/scroll-bar-builder.js
@@ -7,58 +7,57 @@ import { EnumProperty } from '../properties/enum-property.js';
 import { PrimitiveTypeProperty } from '../properties/primitive-type-property.js';
 import { PropertyDescriptor } from '../properties/property-descriptor.js';
 
-import { MxsScrollBar } from '../mxs-scroll-bar.js';
 import { Orientation } from '../../types/orientation.js';
 
 export class ScrollBarBuilder extends UiNodeBuilder {
-    constructor(){
-        super();
+  constructor () {
+    super();
 
-        this._propertyDescriptors['thumbSize'] = new PrimitiveTypeProperty('thumbSize', 'setThumbSize', true, 'number');
-        this._propertyDescriptors['thumbPosition'] = new PrimitiveTypeProperty('thumbPosition', 'setThumbPosition', true, 'number');
+    this._propertyDescriptors['thumbSize'] = new PrimitiveTypeProperty('thumbSize', 'setThumbSize', true, 'number');
+    this._propertyDescriptors['thumbPosition'] = new PrimitiveTypeProperty('thumbPosition', 'setThumbPosition', true, 'number');
 
-        this._propertyDescriptors['orientation'] = new EnumProperty('orientation', 'setOrientation', false, Orientation, 'Orientation');
+    this._propertyDescriptors['orientation'] = new EnumProperty('orientation', 'setOrientation', false, Orientation, 'Orientation');
+  }
+
+  create (prism, properties) {
+    this.throwIfInvalidPrism(prism);
+
+    this.validate(undefined, undefined, properties);
+
+    const width = properties.width;
+    const height = this.getPropertyValue('height', 0, properties);
+
+    const element = ui.UiScrollBar.Create(prism, width, height);
+
+    Object.defineProperty(element, 'Orientation', {
+      enumerable: true,
+      writable: true,
+      configurable: false,
+      value: ui.Orientation.kVertical
+    });
+
+    const unapplied = this.excludeProperties(properties, ['width', 'height']);
+
+    this.apply(element, undefined, unapplied);
+
+    return element;
+  }
+
+  setOrientation (element, oldProperties, newProperties) {
+    const orientation = newProperties.orientation;
+    if (orientation !== undefined) {
+      element.Orientation = Orientation[orientation];
     }
+  }
 
-    create(prism, properties) {
-        this.throwIfInvalidPrism(prism);
+  validate (element, oldProperties, newProperties) {
+    super.validate(element, oldProperties, newProperties);
 
-        this.validate(undefined, undefined, properties);
+    this._validateSize(newProperties);
+  }
 
-        const width  = properties.width;
-        const height = this.getPropertyValue('height', 0, properties);
-
-        const element = MxsScrollBar.Create(prism, width, height);
-
-        Object.defineProperty(element, 'Orientation', {
-            enumerable: true,
-            writable: true,
-            configurable: false,
-            value: ui.Orientation.kVertical
-        });
-
-        const unapplied = this.excludeProperties(properties, ['width', 'height']);
-
-        this.apply(element, undefined, unapplied);
-
-        return element;
-    }
-
-    setOrientation(element, oldProperties, newProperties) {
-        const orientation = newProperties.orientation;
-        if (orientation !== undefined) {
-            element.Orientation = Orientation[orientation];
-        }
-    }
-
-    validate(element, oldProperties, newProperties) {
-        super.validate(element, oldProperties, newProperties);
-
-        this._validateSize(newProperties);
-    }
-
-    _validateSize(properties) {
-        PropertyDescriptor.throwIfNotTypeOf(properties.height, 'number');
-        PropertyDescriptor.throwIfNotTypeOf(properties.width, 'number');
-    }
+  _validateSize (properties) {
+    PropertyDescriptor.throwIfNotTypeOf(properties.height, 'number');
+    PropertyDescriptor.throwIfNotTypeOf(properties.width, 'number');
+  }
 }

--- a/src/platform/lumin-runtime/platform-factory.js
+++ b/src/platform/lumin-runtime/platform-factory.js
@@ -250,8 +250,9 @@ export class PlatformFactory extends NativeFactory {
         } else {
             // Temporary fix for adding child node
             // Use setTimeout(func, 0) in order to let the other threads to catch-up.
-            // parent.addChild(child);
-            setTimeout(() => parent.addChild(child), 0);
+            // setTimeout(() => parent.addChild(child), 0); -> BREAKS Adding child node to UiListViewItem
+            // Switching back to original code:
+            parent.addChild(child);
         }
     }
 


### PR DESCRIPTION
1. Use ui.UiScrollBar instead of MxsScrollBar from ScrollBarBuilder
2. Use ui.UiListViewItem instead of MxsListViewItem from ListViewItemBuilder
3. Set default `width` and `height` for the ListView
4. Revert the code to NOT use the `setTimeout(() => parent.addChild(child))` hack since it breaks adding child to UiListViewItem. According to Wyck Herbert, the UiKit components should be decoupled from scene graph traversal.
