### PR TITLE
Resolve misplacement for the width and height

### DIFF
--- a/src/platform/lumin-runtime/elements/builders/layout-builder.js
+++ b/src/platform/lumin-runtime/elements/builders/layout-builder.js
@@ -25,7 +25,7 @@ export class LayoutBuilder extends UiNodeBuilder {
     }
 
     _setSize(element, properties) {
-        const { height, width } = properties;
+        let { height, width } = properties;
 
         if (width || height) {
             if (width === undefined) {
@@ -36,7 +36,7 @@ export class LayoutBuilder extends UiNodeBuilder {
                 height = element.getSize()[1];
             }
 
-            element.setSize([height, width]);
+            element.setSize([width, height]);
         }
     }
 }


### PR DESCRIPTION
Function _setSize() had misplaced width and height property in the vec2 array.