### PR TITLE
Init Dialog component after content has been added

### DIFF
--- a/src/platform/lumin-runtime/platform-factory.js
+++ b/src/platform/lumin-runtime/platform-factory.js
@@ -218,6 +218,7 @@ export class PlatformFactory extends NativeFactory {
     } else if (parent instanceof ui.UiDialog) {
       if (child instanceof TransformNode) {
         parent.setDialogContent(child);
+        parent.init();
       }
     } else if (parent instanceof ui.UiToggle) {
       if (child instanceof TransformNode) {


### PR DESCRIPTION
According to Lumin Runtime documentation Dialog component needs to be initialized after the content has been set.
