### PR TITLE
Remove redundant prismController calls

### DIFF
--- a/src/platform/lumin-runtime/mxs-landscape-app.js
+++ b/src/platform/lumin-runtime/mxs-landscape-app.js
@@ -31,12 +31,6 @@ export class MxsLandscapeApp extends LandscapeApp {
   }
 
   updateLoop(delta) {
-    for (let controller of this._prismControllers) {
-      if (controller.onUpdate) {
-        controller.onUpdate(delta);
-      }
-    }
-
     if ( this._app.props.updateLoop !== undefined
       && typeof this._app.props.updateLoop === 'function') {
       this._app.props.updateLoop(delta);
@@ -46,16 +40,10 @@ export class MxsLandscapeApp extends LandscapeApp {
   }
 
   eventListener(event) {
-    for (let controller of this._prismControllers) {
-      if (controller.onEvent) {
-        controller.onEvent(event);
-      }
-    }
-
     if ( this._app.props.eventListener !== undefined
       && typeof this._app.props.eventListener === 'function') {
       // TODO: Convert Lumin RT event data to (abstract) Mxs event data
-      this._app.props.eventListener(delta);
+      this._app.props.eventListener(event);
     }
 
     return true;


### PR DESCRIPTION
The onUpdate and onEvent callbacks are invoked automatically by Lumin Runtime
on any PrismControllers attached to a Prism.

Also, fix typo in app props eventListener callback.

Thank you for your contribution to MagicScript Project.
Before submitting this PR, please make sure:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved terminology
- [x] You have added unit tests
