### PR TITLE
Auto-generate TS types from property descriptors

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 import configuration from './src/configuration.js';
+import { generateTypeScript } from './src/util/gen-type-script.js';
 
 export default {
     _init() {
@@ -13,5 +14,7 @@ export default {
 
     getContainer(nodeName) {
         return this._app.getContainer(nodeName);
-    }
+    },
+
+    generateTypeScript
 }

--- a/src/platform/lumin-runtime/elements/builders/audio-builder.js
+++ b/src/platform/lumin-runtime/elements/builders/audio-builder.js
@@ -39,7 +39,7 @@ export class AudioBuilder extends TransformBuilder {
             new PrimitiveTypeProperty('gainMf', undefined, undefined, 'number')
         ];
 
-        this._propertyDescriptors['spatialSoundDirectSendLevels'] = new ClassProperty('spatialSpatialSoundDirectSendLevels', 'setSpatialSoundDirectSendLevels', false, spatialSoundDirectSendLevelsProperties);
+        this._propertyDescriptors['spatialSoundDirectSendLevels'] = new ClassProperty('spatialSoundDirectSendLevels', 'setSpatialSoundDirectSendLevels', false, spatialSoundDirectSendLevelsProperties);
 
         // SpatialSoundDistanceProperties
         const spatialSoundDistanceProperties = [

--- a/src/platform/lumin-runtime/elements/builders/positional-layout-builder.js
+++ b/src/platform/lumin-runtime/elements/builders/positional-layout-builder.js
@@ -12,8 +12,8 @@ export class PositionalLayoutBuilder extends LayoutBuilder {
 
         this._propertyDescriptors['defaultItemAlignment'] = new EnumProperty('defaultItemAlignment', 'setDefaultItemAlignment', true, Alignment, 'Alignment');
         this._propertyDescriptors['defaultItemPadding'] = new ArrayProperty('defaultItemPadding', 'setDefaultItemPadding', true, 'vec4');
-        this._propertyDescriptors['itemAlignment'] = new EnumProperty('defaultItemAlignment', 'setItemAlignment', true, Alignment, 'Alignment');
-        this._propertyDescriptors['itemPadding'] = new ArrayProperty('defaultItemPadding', 'setItemPadding', true, 'vec4');
+        this._propertyDescriptors['itemAlignment'] = new EnumProperty('itemAlignment', 'setItemAlignment', true, Alignment, 'Alignment');
+        this._propertyDescriptors['itemPadding'] = new ArrayProperty('itemPadding', 'setItemPadding', true, 'vec4');
         this._propertyDescriptors['skipInvisibleItems'] = new PrimitiveTypeProperty('skipInvisibleItems', 'setSkipInvisibleItems', true, 'boolean');
     }
 }

--- a/src/platform/lumin-runtime/elements/builders/ui-node-builder.js
+++ b/src/platform/lumin-runtime/elements/builders/ui-node-builder.js
@@ -21,6 +21,9 @@ export class UiNodeBuilder extends TransformBuilder {
     constructor(){
         super();
 
+        this._propertyDescriptors['height'] = new PrimitiveTypeProperty('height', undefined, undefined, 'number');
+        this._propertyDescriptors['width'] = new PrimitiveTypeProperty('width', undefined, undefined, 'number');
+
         // RenderingLayer - second setter
 
         this._propertyDescriptors['alignment'] = new EnumProperty('alignment', 'setAlignment', true, Alignment, 'Alignment');

--- a/src/platform/lumin-runtime/elements/builders/ui-node-builder.js
+++ b/src/platform/lumin-runtime/elements/builders/ui-node-builder.js
@@ -21,9 +21,6 @@ export class UiNodeBuilder extends TransformBuilder {
     constructor(){
         super();
 
-        this._propertyDescriptors['height'] = new PrimitiveTypeProperty('height', undefined, undefined, 'number');
-        this._propertyDescriptors['width'] = new PrimitiveTypeProperty('width', undefined, undefined, 'number');
-
         // RenderingLayer - second setter
 
         this._propertyDescriptors['alignment'] = new EnumProperty('alignment', 'setAlignment', true, Alignment, 'Alignment');

--- a/src/platform/lumin-runtime/elements/properties/array-property.js
+++ b/src/platform/lumin-runtime/elements/properties/array-property.js
@@ -13,4 +13,24 @@ export class ArrayProperty extends PropertyDescriptor {
         this.throwIfNotArray(value, this._arrayType);
         return true;
     }
+
+    tsType() {
+        if (PropertyDescriptor.hasValue(this._arrayType)) {
+            return this._arrayType;
+        } else if (this._name === 'points') {
+            // Special case for LineBuilder
+            return 'vec3[]';
+        }
+        return 'any[]';
+    }
+
+    tsDependentTypes() {
+        return {
+            vec2: '[number, number]',
+            vec3: '[number, number, number]',
+            vec4: '[number, number, number, number]',
+            quat: 'vec4',
+            mat4: '[vec4, vec4, vec4, vec4]'
+        }
+    }
 }

--- a/src/platform/lumin-runtime/elements/properties/class-property.js
+++ b/src/platform/lumin-runtime/elements/properties/class-property.js
@@ -16,4 +16,19 @@ export class ClassProperty extends PropertyDescriptor {
 
         return true;
     }
+
+    tsType() {
+        const propTs = this._properties.map(p => p.generateTypeScript());
+        return `{ ${propTs.join(' ')} }`
+    }
+
+    tsDependentTypes() {
+        let deps = {};
+        this._properties.forEach(p => {
+            if (typeof p.tsDependentTypes === 'function') {
+                deps = {...deps, ...p.tsDependentTypes()};
+            }
+        });
+        return deps;
+    }
 }

--- a/src/platform/lumin-runtime/elements/properties/enum-property.js
+++ b/src/platform/lumin-runtime/elements/properties/enum-property.js
@@ -19,4 +19,12 @@ export class EnumProperty extends PropertyDescriptor {
         this.throwIfConditionFails(value, message, this._enumType[value] !== undefined);
         return true;
     }
+
+    tsType() {
+        return this._enumName;
+    }
+
+    tsDependentTypes() {
+        return { [this._enumName]: "'" + Object.keys(this._enumType).join("' | '") + "'"};
+    }
 }

--- a/src/platform/lumin-runtime/elements/properties/primitive-type-property.js
+++ b/src/platform/lumin-runtime/elements/properties/primitive-type-property.js
@@ -13,4 +13,8 @@ export class PrimitiveTypeProperty extends PropertyDescriptor {
         this.throwIfNotTypeOf(value, this._typeName);
         return true;
     }
+
+    tsType() {
+        return this._typeName;;
+    }
 }

--- a/src/platform/lumin-runtime/elements/properties/property-descriptor.js
+++ b/src/platform/lumin-runtime/elements/properties/property-descriptor.js
@@ -110,4 +110,16 @@ export class PropertyDescriptor {
             throw new TypeError(message);
         }
     }
+
+    tsType() {
+        return 'any';
+    }
+
+    tsDependentTypes() {
+        return {};
+    }
+
+    generateTypeScript() {
+        return `${this._name}?: ${this.tsType()};`;
+    }
 }

--- a/src/util/gen-type-script.js
+++ b/src/util/gen-type-script.js
@@ -1,0 +1,39 @@
+import configuration from "../configuration.js";
+
+export function generateTypeScript () {
+  let str = 'declare module "magic-script-components" {\n\n';
+
+  str += '  // Components:\n'
+  str += '  // --------------------------------------------------------------------------------\n\n'
+  let deps = {};
+
+  const elements = configuration.nativeMapping.elements;
+  for (let elementName in elements) {
+    const builder = elements[elementName]();
+    // captialize the name to match exposed Component name
+    elementName = elementName[0].toUpperCase() + elementName.slice(1)
+    str += `  interface ${elementName}Props {\n`
+
+    for (let propName in builder._propertyDescriptors) {
+      const propertyDescriptor = builder._propertyDescriptors[propName];
+      if (propertyDescriptor.Name !== propName) {
+        throw `Mismatched prop name, ${elementName}.${propName} !== ${propertyDescriptor.Name}`;
+      }
+      const propTs = propertyDescriptor.generateTypeScript();
+      deps = {...deps, ...propertyDescriptor.tsDependentTypes()};
+      str += `    ${propTs}\n`;
+    }
+
+    str += '  }\n\n';
+    str += `  const ${elementName}: React.FC<${elementName}Props>;\n\n`
+  }
+
+  str += '  // Other Types:\n'
+  str += '  // --------------------------------------------------------------------------------\n\n'
+  for (let dep in deps) {
+    str += `  type ${dep} = ${deps[dep]};\n\n`;
+  }
+  str += '}\n';
+
+  return str;
+}


### PR DESCRIPTION
TS generator also checks for mismatched property descriptor names -- this change fixes a few.

Also, add width and height property descriptors to UiNode (they are used in various subclasses -- need to confirm this is the best approach).