### PR TITLE
Do not update the action if value has not changed

### DIFF
--- a/src/platform/lumin-runtime/elements/builders/audio-builder.js
+++ b/src/platform/lumin-runtime/elements/builders/audio-builder.js
@@ -227,6 +227,12 @@ export class AudioBuilder extends TransformBuilder {
             return
         }
 
+        if (oldProperties !== undefined &&
+            oldProperties.action !== undefined &&
+            oldProperties.action === action) {
+            return;
+        }
+
         if (AudioAction[action] === AudioAction.start) {
             element.startSound();
         } else if (AudioAction[action] === AudioAction.stop) {


### PR DESCRIPTION
If the `action` property value has not changed do not execute the corresponding audio node function.