### PR TITLE
Rename property 'text' into 'message'.

### DIFF
--- a/src/platform/lumin-runtime/elements/builders/dialog-builder.js
+++ b/src/platform/lumin-runtime/elements/builders/dialog-builder.js
@@ -38,6 +38,10 @@ export class DialogBuilder extends TextProviderBuilder {
             message = this._getText(properties.children);
         }
 
+        if (message === undefined) {
+            message = '';
+        }
+
         const type = this.getPropertyValue('type', 'dual-action', properties);
         const layout = this.getPropertyValue('layout', 'standard', properties);
         const scrolling = this.getPropertyValue('scrolling', false, properties);

--- a/src/platform/lumin-runtime/elements/builders/dialog-builder.js
+++ b/src/platform/lumin-runtime/elements/builders/dialog-builder.js
@@ -32,10 +32,10 @@ export class DialogBuilder extends TextProviderBuilder {
 
         this.validate(undefined, undefined, properties);
 
-        let text = properties.text;
+        let message = properties.message;
 
-        if (text === undefined) {
-            text = this._getText(properties.children);
+        if (message === undefined) {
+            message = this._getText(properties.children);
         }
 
         const type = this.getPropertyValue('type', 'dual-action', properties);
@@ -46,14 +46,14 @@ export class DialogBuilder extends TextProviderBuilder {
         let element
 
         if (scrolling) {
-            element = ui.UiDialog.CreateScrolling(prism, title, text, DialogType[type], DialogLayout[layout]);
+            element = ui.UiDialog.CreateScrolling(prism, title, message, DialogType[type], DialogLayout[layout]);
         } else {
             element = title === undefined
                 ? ui.UiDialog.Create(prism, DialogType[type], DialogLayout[layout])
-                : ui.UiDialog.Create(prism, title, text, null, DialogType[type], DialogLayout[layout]);
+                : ui.UiDialog.Create(prism, title, message, null, DialogType[type], DialogLayout[layout]);
         }
 
-        const unapplied = this.excludeProperties(properties, ['children', 'text', 'title', 'type', 'layout']);
+        const unapplied = this.excludeProperties(properties, ['children', 'message', 'title', 'type', 'layout']);
 
         this.apply(element, undefined, unapplied);
 


### PR DESCRIPTION
@grozdanov In UiDialog.h there is an argument called `message` (not `text`) in Create functions.
Based on UiDialog.h we also defined the property `message` in iOS and Android code.
Shall we change your code so this it is consistent across all platforms?

FYI Native iOS alert also defines `title` and `message` fields so I would opt for the 'message' prop. What do you think?