### PR TITLE
Rollback the setTimeout for add/remove nodes

### DIFF
--- a/src/platform/lumin-runtime/controllers/mxs-prism-controller.js
+++ b/src/platform/lumin-runtime/controllers/mxs-prism-controller.js
@@ -53,10 +53,7 @@ export class MxsPrismController extends PrismController {
         if (root === undefined || root === null) {
             this._children.push(child);
         } else {
-            // Temporary fix for adding child node
-            // Use setTimeout(func, 0) in order to let the other threads to catch-up.
-            // root.addChild(child);
-            setTimeout(() => root.addChild(child), 0);
+            root.addChild(child);
         }
     }
 
@@ -69,12 +66,7 @@ export class MxsPrismController extends PrismController {
             this._controllers.push(controller);
         } else {
             super.addChildController(controller);
-
-            // Temporary fix for adding child node
-            // Use setTimeout(func, 0) in order to let the other threads to catch-up.
-            // this.addChild(controller.getRoot());
-            const node = this;
-            setTimeout(() => node.addChild(controller.getRoot()), 0);
+            this.addChild(controller.getRoot());
         }
     }
 
@@ -124,19 +116,13 @@ export class MxsPrismController extends PrismController {
         if (this._controllers !== undefined) {
             this._controllers.forEach(controller => {
                 super.addChildController(controller);
-                // Temporary fix for adding child node
-                // Use setTimeout(func, 0) in order to let the other threads to catch-up.
-                // root.addChild(controller.getRoot());
-                setTimeout(() => root.addChild(controller.getRoot()), 0);
+                root.addChild(controller.getRoot());
             });
             this._controllers = undefined;
         }
 
         if (this._children !== undefined) {
-            // Temporary fix for adding child node
-            // Use setTimeout(func, 0) in order to let the other threads to catch-up.
-            // this._children.forEach(child => root.addChild(child));
-            this._children.forEach(child => setTimeout(() => root.addChild(child), 0));
+            this._children.forEach(child => root.addChild(child));
             this._children = undefined;
         }
 

--- a/src/platform/lumin-runtime/platform-factory.js
+++ b/src/platform/lumin-runtime/platform-factory.js
@@ -85,10 +85,7 @@ export class PlatformFactory extends NativeFactory {
           if (this.isController(child)) {
             element.addChildController(child);
           } else {
-            // Temporary fix for adding child node
-            // Use setTimeout(func, 0) in order to let the other threads to catch-up.
-            // element.addChild(child);
-            setTimeout(() => element.addChild(child), 0);
+            element.addChild(child);
             if (child.childController !== undefined) {
               element.addChildController(child.childController);
             }
@@ -97,10 +94,7 @@ export class PlatformFactory extends NativeFactory {
           if (this.isController(child)) {
             element.childController = child;
             const handler = () => {
-              // Temporary fix for adding child node
-              // Use setTimeout(func, 0) in order to let the other threads to catch-up.
-              // element.addChild(child.getRoot());
-              setTimeout(() => element.addChild(child.getRoot()), 0);
+              element.addChild(child.getRoot());
               child.removeListener('onAttachPrism', handler);
             };
 
@@ -279,10 +273,6 @@ export class PlatformFactory extends NativeFactory {
         }
       }
     } else {
-      // Temporary fix for adding child node
-      // Use setTimeout(func, 0) in order to let the other threads to catch-up.
-      // setTimeout(() => parent.addChild(child), 0); -> BREAKS Adding child node to UiListViewItem
-      // Switching back to original code:
       parent.addChild(child);
     }
   }
@@ -353,28 +343,14 @@ export class PlatformFactory extends NativeFactory {
         }
         parent.removeChildController(child);
       } else if (this.isController(parent)) {
-        // Temporary fix for adding child node
-        // Use setTimeout(func, 0) in order to let the other threads to catch-up.
-        // parent.getRoot().removeChild(child);
-        // parent.getPrism().deleteNode(child);
-        setTimeout(() => {
-          parent.getRoot().removeChild(child);
-          parent.getPrism().deleteNode(child);
-        }, 0);
+        parent.getRoot().removeChild(child);
+        parent.getPrism().deleteNode(child);
       } else if (parent instanceof ui.UiListView) {
         parent.removeItem(this._getListViewIndex(parent, child));
       } else {
-        // Temporary fix for adding child node
-        // Use setTimeout(func, 0) in order to let the other threads to catch-up.
-        // parent.removeChild(child);
-        // const prism = this._app.getPrism(child.getPrismId());
-        // prism.deleteNode(child);
-        const factory = this;
-        setTimeout(() => {
-          parent.removeChild(child);
-          const prism = factory._app.getPrism(child.getPrismId());
-          prism.deleteNode(child);
-        }, 0);
+        parent.removeChild(child);
+        const prism = this._app.getPrism(child.getPrismId());
+        prism.deleteNode(child);
       }
     }
   }
@@ -385,15 +361,9 @@ export class PlatformFactory extends NativeFactory {
 
     if (this.isController(child)) {
       container.controller.addChildController(child);
-      // Temporary fix for adding child node
-      // Use setTimeout(func, 0) in order to let the other threads to catch-up.
-      // container.parent.addChild(child.getRoot());
-      setTimeout(() => container.parent.addChild(child.getRoot()), 0);
+      container.parent.addChild(child.getRoot());
     } else {
-      // Temporary fix for adding child node
-      // Use setTimeout(func, 0) in order to let the other threads to catch-up.
-      // container.controller.getRoot().addChild(child);
-      setTimeout(() => container.controller.getRoot().addChild(child), 0);
+      container.controller.getRoot().addChild(child);
     }
   }
 
@@ -401,15 +371,9 @@ export class PlatformFactory extends NativeFactory {
     if (this.isController(child)) {
       container.controller.removeChildController(child);
     } else {
-      // Temporary fix for adding child node
-      // Use setTimeout(func, 0) in order to let the other threads to catch-up.
-      // container.controller.getRoot().removeChild(child);
-      const factory = this;
-      setTimeout(() => {
-        container.controller.getRoot().removeChild(child);
-        const prism = factory._app.getPrism(child.getPrismId());
-        prism.deleteNode(child);
-      }, 0);
+      container.controller.getRoot().removeChild(child);
+      const prism = this._app.getPrism(child.getPrismId());
+      prism.deleteNode(child);
     }
   }
 

--- a/src/react-magic-script/magic-script-renderer.js
+++ b/src/react-magic-script/magic-script-renderer.js
@@ -279,10 +279,7 @@ function insertBefore(parentInstance, child, beforeChild) {
   } else if (typeof child === 'number') {
     parentInstance.setText(child.toString());
   } else {
-    // Temporary fix for adding child node
-    // Use setTimeout(func, 0) in order to let the other threads to catch-up.
-    // parentInstance.addChild(child);
-    setTimeout(() => parentInstance.addChild(child), 0);
+    parentInstance.addChild(child);
   }
 }
 


### PR DESCRIPTION
Problem: ver. 1.0.3 does not allow the application to receive focus so the UI components cannot receive the control events. The main change was introducing the `setTimeout( <add/remove child node callback>, 0)`  in order to avoid modifying the scene graph during traversal. 

Solution: Removing the use of `setTimeout` since that breaks the sequence of adding children and routing the events. In a discussion with members from Lumin Runtime /UiKit it was expressed opinion that using `seTimeout` actually should not be required. 
