### PR TITLE
Resolve typo for setting Type property

### DIFF
--- a/src/platform/lumin-runtime/elements/builders/light-builder.js
+++ b/src/platform/lumin-runtime/elements/builders/light-builder.js
@@ -18,7 +18,7 @@ export class LightBuilder extends TransformBuilder {
         this._propertyDescriptors['intensity'] = new PrimitiveTypeProperty('intensity', 'setIntensity', true, 'number');
         this._propertyDescriptors['range'] = new PrimitiveTypeProperty('range', 'setRange', true, 'number');
         this._propertyDescriptors['spotAngle'] = new PrimitiveTypeProperty('spotAngle', 'setSpotAngle', true, 'number');
-        this._propertyDescriptors['type'] = new EnumProperty('type', '// setType', true, LightType, 'LightType');
+        this._propertyDescriptors['type'] = new EnumProperty('type', 'setType', true, LightType, 'LightType');
         this._propertyDescriptors['castsShadows'] = new PrimitiveTypeProperty('castsShadows', 'trySetCastsShadows', true, 'boolean');
 
         // setUseHeadPose


### PR DESCRIPTION
Remove `//` left by mistake as part of the setting method for light type property.
