### PR TITLE
Set the correct property type for Button.iconSize

### DIFF
--- a/src/platform/lumin-runtime/elements/builders/button-builder.js
+++ b/src/platform/lumin-runtime/elements/builders/button-builder.js
@@ -16,7 +16,7 @@ export class ButtonBuilder extends TextContainerBuilder {
     constructor(){
         super();
 
-        this._propertyDescriptors['iconSize'] = new PrimitiveTypeProperty('iconSize', 'setIconSize', true, 'vec2');
+        this._propertyDescriptors['iconSize'] = new ArrayProperty('iconSize', 'setIconSize', true, 'vec2');
         this._propertyDescriptors['iconColor'] = new ArrayProperty('iconColor', 'setIconColor', true, 'vec4');
     }
 


### PR DESCRIPTION
Button.iconSize had the wrong property type `PrimitiveTypeProperty`. The proper type is `ArrayProperty`.
