### PR TITLE
Export event data types

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,6 +36,6 @@ export { PrismEventData } from './src/platform/lumin-runtime/types/event-data/pr
 export { ProgressBarEventData } from './src/platform/lumin-runtime/types/event-data/progress-bar-event-data.js';
 export { ScrollBarEventData } from './src/platform/lumin-runtime/types/event-data/scroll-bar-event-data.js';
 export { ScrollViewEventData } from './src/platform/lumin-runtime/types/event-data/scroll-view-event-data.js';
-export { SliderEventData } from './src/platform/lumin-runtime/types/event-data/text-edit-event-data.js';
+export { SliderEventData } from './src/platform/lumin-runtime/types/event-data/slider-event-data';
 export { TextEditEventData } from './src/platform/lumin-runtime/types/event-data/text-edit-event-data.js';
 export { ToggleEventData } from './src/platform/lumin-runtime/types/event-data/toggle-event-data.js';

--- a/index.js
+++ b/index.js
@@ -18,24 +18,3 @@ export default {
 
     generateTypeScript
 }
-
-export { ControlTouchPadInputEventData } from './src/platform/lumin-runtime/types/event-data/control-touch-pad-input-event-data.js';
-export { ControlPose3DofInputEventData } from './src/platform/lumin-runtime/types/event-data/control-pose-3dof-Input-event-data.js';
-export { ControlPose6DofInputEventData } from './src/platform/lumin-runtime/types/event-data/control-pose-6dof-input-event-data.js';
-export { EyeTrackingEventData } from './src/platform/lumin-runtime/types/event-data/eye-tracking-event-data.js';
-export { GestureInputEventData } from './src/platform/lumin-runtime/types/event-data/gesture-input-event-data.js';
-export { InputEventData } from './src/platform/lumin-runtime/types/event-data/input-event-data.js';
-export { KeyInputEventData } from './src/platform/lumin-runtime/types/event-data/key-input-event-data.js';
-export { RayCastEventData } from './src/platform/lumin-runtime/types/event-data/ray-cast-event-data.js';
-export { SelectionEventData } from './src/platform/lumin-runtime/types/event-data/selection-event-data.js';
-export { UiEventData } from './src/platform/lumin-runtime/types/event-data/ui-event-data.js';
-export { VideoEventData } from './src/platform/lumin-runtime/types/event-data/video-event-data.js';
-
-export { DropDownListEventData } from './src/platform/lumin-runtime/types/event-data/drop-down-list-event-data.js';
-export { PrismEventData } from './src/platform/lumin-runtime/types/event-data/prism-event-data.js';
-export { ProgressBarEventData } from './src/platform/lumin-runtime/types/event-data/progress-bar-event-data.js';
-export { ScrollBarEventData } from './src/platform/lumin-runtime/types/event-data/scroll-bar-event-data.js';
-export { ScrollViewEventData } from './src/platform/lumin-runtime/types/event-data/scroll-view-event-data.js';
-export { SliderEventData } from './src/platform/lumin-runtime/types/event-data/text-edit-event-data.js';
-export { TextEditEventData } from './src/platform/lumin-runtime/types/event-data/text-edit-event-data.js';
-export { ToggleEventData } from './src/platform/lumin-runtime/types/event-data/toggle-event-data.js';

--- a/index.js
+++ b/index.js
@@ -18,3 +18,24 @@ export default {
 
     generateTypeScript
 }
+
+export { ControlTouchPadInputEventData } from './src/platform/lumin-runtime/types/event-data/control-touch-pad-input-event-data.js';
+export { ControlPose3DofInputEventData } from './src/platform/lumin-runtime/types/event-data/control-pose-3dof-Input-event-data.js';
+export { ControlPose6DofInputEventData } from './src/platform/lumin-runtime/types/event-data/control-pose-6dof-input-event-data.js';
+export { EyeTrackingEventData } from './src/platform/lumin-runtime/types/event-data/eye-tracking-event-data.js';
+export { GestureInputEventData } from './src/platform/lumin-runtime/types/event-data/gesture-input-event-data.js';
+export { InputEventData } from './src/platform/lumin-runtime/types/event-data/input-event-data.js';
+export { KeyInputEventData } from './src/platform/lumin-runtime/types/event-data/key-input-event-data.js';
+export { RayCastEventData } from './src/platform/lumin-runtime/types/event-data/ray-cast-event-data.js';
+export { SelectionEventData } from './src/platform/lumin-runtime/types/event-data/selection-event-data.js';
+export { UiEventData } from './src/platform/lumin-runtime/types/event-data/ui-event-data.js';
+export { VideoEventData } from './src/platform/lumin-runtime/types/event-data/video-event-data.js';
+
+export { DropDownListEventData } from './src/platform/lumin-runtime/types/event-data/drop-down-list-event-data.js';
+export { PrismEventData } from './src/platform/lumin-runtime/types/event-data/prism-event-data.js';
+export { ProgressBarEventData } from './src/platform/lumin-runtime/types/event-data/progress-bar-event-data.js';
+export { ScrollBarEventData } from './src/platform/lumin-runtime/types/event-data/scroll-bar-event-data.js';
+export { ScrollViewEventData } from './src/platform/lumin-runtime/types/event-data/scroll-view-event-data.js';
+export { SliderEventData } from './src/platform/lumin-runtime/types/event-data/text-edit-event-data.js';
+export { TextEditEventData } from './src/platform/lumin-runtime/types/event-data/text-edit-event-data.js';
+export { ToggleEventData } from './src/platform/lumin-runtime/types/event-data/toggle-event-data.js';


### PR DESCRIPTION
Export event data types consumed from onEvent(eventData) event:
- ControlPose3DofInputEventData
- ControlPose6DofInputEventData
- ControlTouchPadInputEventData
- EyeTrackingEventData
- GestureInputEventData
- InputEventData
- KeyInputEventData
- RayCastEventData
- SelectionEventData
- UiEventData
- VideoEventData
