### PR TITLE
Resolve exception of reading property name of undefined

### DIFF
--- a/src/platform/lumin-runtime/elements/properties/component-children-property.js
+++ b/src/platform/lumin-runtime/elements/properties/component-children-property.js
@@ -18,7 +18,9 @@ export class ComponentChildrenProperty extends PropertyDescriptor {
   }
 
   static isValid (children) {
-    return this.hasValue(children) && this._isComponent(children);
+    return this.hasValue(children) &&
+           typeof children === 'object' &&
+           this._isComponent(children);
   }
 
   static throwIfNotComponent (children) {


### PR DESCRIPTION
Check children property for being object before checking if that object is a Content component.
