### PR TITLE
Fix onHoverMove typo

### DIFF
--- a/src/platform/lumin-runtime/platform-factory.js
+++ b/src/platform/lumin-runtime/platform-factory.js
@@ -35,9 +35,11 @@ export class PlatformFactory extends NativeFactory {
 
       if (eventDescriptor !== undefined) {
         if (typeof pair.handler === 'function') {
-          element[eventDescriptor.subName]((eventData) => {
-            pair.handler(new eventDescriptor.dataType(eventData));
-          });
+          try {
+            element[eventDescriptor.subName]((eventData) => pair.handler(new eventDescriptor.dataType(eventData)));
+          } catch (error) {
+            throw new Error(`Tyring to subscribe handler ${pair.name} to ${eventDescriptor.subName} failed, error: ${error.message}`);
+          }
         } else {
           throw new TypeError(`The event handler for ${pair.name} is not a function`);
         }

--- a/src/platform/lumin-runtime/types/ui-node-events.js
+++ b/src/platform/lumin-runtime/types/ui-node-events.js
@@ -29,7 +29,7 @@ export const UiNodeEvents = {
     'onRelease': { subName: 'onReleasedSub', dataType: UiEventData },
     'onHoverEnter': { subName: 'onHoverEnterSub', dataType: UiEventData },
     'onHoverExit': { subName: 'onHoverExitSub', dataType: UiEventData },
-    'onHoverMove': { subName: 'onHoveMoveSub', dataType: UiEventData },
+    'onHoverMove': { subName: 'onHoverMoveSub', dataType: UiEventData },
     'onEnabled': { subName: 'onEnabledSub', dataType: UiEventData },
     'onDisabled': { subName: 'onDisabledSub', dataType: UiEventData },
     'onFocusGained': { subName: 'onFocusGainedSub', dataType: UiEventData },


### PR DESCRIPTION
1. The event name was `onHoveMove` instead of `onHoverMove`.
2. Enrich the error with more information when subscribing to event fails.
