### PR TITLE
Remove log message for missing property descriptor

### DIFF
--- a/src/platform/lumin-runtime/elements/builders/element-builder.js
+++ b/src/platform/lumin-runtime/elements/builders/element-builder.js
@@ -25,13 +25,10 @@ export class ElementBuilder {
     }
 
     _applyAction(properties, action){
-
         for (const name of Object.keys(properties)) {
             const descriptor = this._propertyDescriptors[name];
             if (descriptor !== undefined) {
                 action(properties[name], descriptor);
-            } else {
-                console.log(`Property ${name} does not have a descriptor`);
             }
         }
     }


### PR DESCRIPTION
There are some properties which are used only during creation and do not have property descriptors. In order to avoid polluting the log it became necessary to remove the missing property descriptor log message.
