### PR TITLE
Add support for class array properties

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
   "homepage": "https://github.com/magic-script/magic-script-components-lumin#readme",
   "dependencies": {
     "react": "^16.9.0",
-    "react-reconciler": "^0.21.0"
+    "react-reconciler": "^0.21.0",
+    "chroma-js": "^2.1.0"
   },
   "peerDependencies": {
     "@babel/core": "^7.6.0",

--- a/src/platform/lumin-runtime/elements/builders/element-builder.js
+++ b/src/platform/lumin-runtime/elements/builders/element-builder.js
@@ -30,8 +30,6 @@ export class ElementBuilder {
             const descriptor = this._propertyDescriptors[name];
             if (descriptor !== undefined) {
                 action(properties[name], descriptor);
-            } else {
-                console.log(`Property ${name} does not have a descriptor`);
             }
         }
     }

--- a/src/platform/lumin-runtime/elements/builders/grid-layout-builder.js
+++ b/src/platform/lumin-runtime/elements/builders/grid-layout-builder.js
@@ -11,6 +11,24 @@ export class GridLayoutBuilder extends PositionalLayoutBuilder {
 
         this._propertyDescriptors['columns'] = new PrimitiveTypeProperty('columns', 'setColumns', true, 'number');
         this._propertyDescriptors['rows'] = new PrimitiveTypeProperty('rows', 'setRows', true, 'number');
+
+        // itemAlignment
+        const itemAlignmentProperties = [
+            new PrimitiveTypeProperty('row', undefined, undefined, 'number'),
+            new PrimitiveTypeProperty('column', undefined, undefined, 'number'),
+            new EnumProperty('alignment', undefined, undefined, Alignment, 'Alignment')
+        ];
+
+        this._propertyDescriptors['itemAlignment'] = new ClassProperty('itemAlignment', 'setItemAlignment', false, itemAlignmentProperties);
+
+        // itemPadding
+        const itemPaddingProperties = [
+            new PrimitiveTypeProperty('row', undefined, undefined, 'number'),
+            new PrimitiveTypeProperty('column', undefined, undefined, 'number'),
+            new ArrayProperty('padding', undefined, undefined, 'vec4')
+        ];
+
+        this._propertyDescriptors['itemPadding'] = new ClassProperty('itemPadding', 'setItemPadding', false, itemPaddingProperties);
     }
 
     create(prism, properties) {
@@ -21,5 +39,15 @@ export class GridLayoutBuilder extends PositionalLayoutBuilder {
         this.update(element, undefined, properties);
 
         return element;
+    }
+
+    setItemAlignment (element, oldProperties, newProperties) {
+        newProperties.itemAlignment
+          .forEach(({ row, column, alignment }) => element.setItemAlignment(row, column, Alignment[alignment]));
+    }
+
+    setItemPadding (element, oldProperties, newProperties) {
+        newProperties.itemPadding
+          .forEach(({ row, column, padding }) => element.setItemPadding(row, column, padding));
     }
 }

--- a/src/platform/lumin-runtime/elements/builders/grid-layout-builder.js
+++ b/src/platform/lumin-runtime/elements/builders/grid-layout-builder.js
@@ -36,41 +36,45 @@ export class GridLayoutBuilder extends PositionalLayoutBuilder {
 
         const element = ui.UiGridLayout.Create(prism);
 
-        Object.defineProperty(element, 'itemPadding', {
-            enumerable: true,
-            writable: true,
-            configurable: false,
-            value: []
-        });
-
-        Object.defineProperty(element, 'mxsUpdateItemPadding', {
-            enumerable: true,
-            writable: true,
-            configurable: false,
-            value: () => {
-                element.itemAlignment.forEach(({ row, column, padding }) => element.setItemPadding(row, column, padding));
-            }
-        });
-
-        Object.defineProperty(element, 'itemAlignment', {
-            enumerable: true,
-            writable: true,
-            configurable: false,
-            value: []
-        });
-
-        Object.defineProperty(element, 'mxsUpdateItemAlignment', {
-            enumerable: true,
-            writable: true,
-            configurable: false,
-            value: () => {
-                element.itemAlignment.forEach(({ row, column, alignment }) => element.setItemAlignment(row, column, Alignment[alignment]));
-            }
-        });
+        this._addCustomProperties(element);
 
         this.update(element, undefined, properties);
 
         return element;
+    }
+
+    _addCustomProperties (element) {
+        Object.defineProperty(element, 'itemPadding', {
+          enumerable: true,
+          writable: true,
+          configurable: false,
+          value: []
+        });
+
+        Object.defineProperty(element, 'mxsUpdateItemPadding', {
+          enumerable: true,
+          writable: true,
+          configurable: false,
+          value: () => {
+            element.itemPadding.forEach(({ row, column, padding }) => element.setItemPadding(row, column, padding));
+          }
+        });
+
+        Object.defineProperty(element, 'itemAlignment', {
+          enumerable: true,
+          writable: true,
+          configurable: false,
+          value: []
+        });
+
+        Object.defineProperty(element, 'mxsUpdateItemAlignment', {
+          enumerable: true,
+          writable: true,
+          configurable: false,
+          value: () => {
+            element.itemAlignment.forEach(({ row, column, alignment }) => element.setItemAlignment(row, column, Alignment[alignment]));
+          }
+        });
     }
 
     setItemAlignment (element, oldProperties, newProperties) {

--- a/src/platform/lumin-runtime/elements/builders/grid-layout-builder.js
+++ b/src/platform/lumin-runtime/elements/builders/grid-layout-builder.js
@@ -80,7 +80,7 @@ export class GridLayoutBuilder extends PositionalLayoutBuilder {
 
         Object.defineProperty(element, 'mxsSetItemPadding', {
           enumerable: true,
-          writable: true,
+          writable: false,
           configurable: false,
           value: (itemIndex) => {
             if (itemIndex < element.getItemCount()) {
@@ -103,7 +103,7 @@ export class GridLayoutBuilder extends PositionalLayoutBuilder {
 
         Object.defineProperty(element, 'mxsSetItemAlignment', {
           enumerable: true,
-          writable: true,
+          writable: false,
           configurable: false,
           value: (itemIndex) => {
             if (itemIndex < element.getItemCount()) {

--- a/src/platform/lumin-runtime/elements/builders/grid-layout-builder.js
+++ b/src/platform/lumin-runtime/elements/builders/grid-layout-builder.js
@@ -48,19 +48,18 @@ export class GridLayoutBuilder extends PositionalLayoutBuilder {
     }
 
     _addCustomProperties (element) {
-        const getItemCell = (element, item) => {
+        const getItemCell = (gridLayout, item) => {
           const nodeId = item.getNodeId();
-          const rows = element.getCurrentRows();
-          const columns = element.getCurrentColumns();
+          const rows = gridLayout.getCurrentRows();
+          const columns = gridLayout.getCurrentColumns();
           let row = 0;
           let column = 0;
-          let found = false;
 
-          while (!found && row < rows) {
-            while (!found && column < columns) {
-              const node = element.getItem(row, column);
+          while (row < rows) {
+            while (column < columns) {
+              const node = gridLayout.getItem(row, column);
               if (node !== null && node.getNodeId() === nodeId) {
-                found = true;
+                return { row, column };
               } else {
                 column++;
               }
@@ -69,7 +68,7 @@ export class GridLayoutBuilder extends PositionalLayoutBuilder {
             row++;
           }
 
-          return found ? { row, column } : undefined;
+          return undefined;
         };
 
         Object.defineProperty(element, 'itemPadding', {
@@ -85,7 +84,7 @@ export class GridLayoutBuilder extends PositionalLayoutBuilder {
           configurable: false,
           value: (itemIndex) => {
             if (itemIndex < element.getItemCount()) {
-              const cell = getItemCell(element.getItem(itemIndex));
+              const cell = getItemCell(element, element.getItem(itemIndex));
               if (cell !== undefined) {
                 element.itemPadding
                   .filter(({ row, column }) => row === cell.row && cell.column === column)
@@ -108,7 +107,7 @@ export class GridLayoutBuilder extends PositionalLayoutBuilder {
           configurable: false,
           value: (itemIndex) => {
             if (itemIndex < element.getItemCount()) {
-              const cell = getItemCell(element.getItem(itemIndex));
+              const cell = getItemCell(element, element.getItem(itemIndex));
               if (cell !== undefined) {
                 element.itemAlignment
                   .filter(({ row, column }) => row === cell.row && cell.column === column)

--- a/src/platform/lumin-runtime/elements/builders/grid-layout-builder.js
+++ b/src/platform/lumin-runtime/elements/builders/grid-layout-builder.js
@@ -3,7 +3,11 @@
 import { ui } from 'lumin';
 
 import { PositionalLayoutBuilder } from './positional-layout-builder.js';
+import { ArrayProperty } from '../properties/array-property.js';
+import { ClassProperty } from '../properties/class-property.js';
+import { EnumProperty } from '../properties/enum-property.js';
 import { PrimitiveTypeProperty } from '../properties/primitive-type-property.js';
+import { Alignment } from '../../types/alignment.js';
 
 export class GridLayoutBuilder extends PositionalLayoutBuilder {
     constructor(){

--- a/src/platform/lumin-runtime/elements/builders/grid-layout-builder.js
+++ b/src/platform/lumin-runtime/elements/builders/grid-layout-builder.js
@@ -36,18 +36,50 @@ export class GridLayoutBuilder extends PositionalLayoutBuilder {
 
         const element = ui.UiGridLayout.Create(prism);
 
+        Object.defineProperty(element, 'itemPadding', {
+            enumerable: true,
+            writable: true,
+            configurable: false,
+            value: []
+        });
+
+        Object.defineProperty(element, 'mxsUpdateItemPadding', {
+            enumerable: true,
+            writable: true,
+            configurable: false,
+            value: () => {
+                element.itemAlignment.forEach(({ row, column, padding }) => element.setItemPadding(row, column, padding));
+            }
+        });
+
+        Object.defineProperty(element, 'itemAlignment', {
+            enumerable: true,
+            writable: true,
+            configurable: false,
+            value: []
+        });
+
+        Object.defineProperty(element, 'mxsUpdateItemAlignment', {
+            enumerable: true,
+            writable: true,
+            configurable: false,
+            value: () => {
+                element.itemAlignment.forEach(({ row, column, alignment }) => element.setItemAlignment(row, column, Alignment[alignment]));
+            }
+        });
+
         this.update(element, undefined, properties);
 
         return element;
     }
 
     setItemAlignment (element, oldProperties, newProperties) {
-        newProperties.itemAlignment
-          .forEach(({ row, column, alignment }) => element.setItemAlignment(row, column, Alignment[alignment]));
+      this._setPropertyValue(element, oldProperties, newProperties, 'itemAlignment',
+        ({ row, column, alignment }) => element.setItemAlignment(row, column, Alignment[alignment]));
     }
 
     setItemPadding (element, oldProperties, newProperties) {
-        newProperties.itemPadding
-          .forEach(({ row, column, padding }) => element.setItemPadding(row, column, padding));
+      this._setPropertyValue(element, oldProperties, newProperties, 'itemPadding',
+        ({ row, column, padding }) => element.setItemPadding(row, column, padding));
     }
 }

--- a/src/platform/lumin-runtime/elements/builders/grid-layout-builder.js
+++ b/src/platform/lumin-runtime/elements/builders/grid-layout-builder.js
@@ -48,6 +48,30 @@ export class GridLayoutBuilder extends PositionalLayoutBuilder {
     }
 
     _addCustomProperties (element) {
+        const getItemCell = (element, item) => {
+          const nodeId = item.getNodeId();
+          const rows = element.getCurrentRows();
+          const columns = element.getCurrentColumns();
+          let row = 0;
+          let column = 0;
+          let found = false;
+
+          while (!found && row < rows) {
+            while (!found && column < columns) {
+              const node = element.getItem(row, column);
+              if (node !== null && node.getNodeId() === nodeId) {
+                found = true;
+              } else {
+                column++;
+              }
+            }
+            column = 0;
+            row++;
+          }
+
+          return found ? { row, column } : undefined;
+        };
+
         Object.defineProperty(element, 'itemPadding', {
           enumerable: true,
           writable: true,
@@ -55,12 +79,19 @@ export class GridLayoutBuilder extends PositionalLayoutBuilder {
           value: []
         });
 
-        Object.defineProperty(element, 'mxsUpdateItemPadding', {
+        Object.defineProperty(element, 'mxsSetItemPadding', {
           enumerable: true,
           writable: true,
           configurable: false,
-          value: () => {
-            element.itemPadding.forEach(({ row, column, padding }) => element.setItemPadding(row, column, padding));
+          value: (itemIndex) => {
+            if (itemIndex < element.getItemCount()) {
+              const cell = getItemCell(element.getItem(itemIndex));
+              if (cell !== undefined) {
+                element.itemPadding
+                  .filter(({ row, column }) => row === cell.row && cell.column === column)
+                  .forEach(({ row, column, padding }) => element.setItemPadding(row, column, padding));
+              }
+            }
           }
         });
 
@@ -71,12 +102,19 @@ export class GridLayoutBuilder extends PositionalLayoutBuilder {
           value: []
         });
 
-        Object.defineProperty(element, 'mxsUpdateItemAlignment', {
+        Object.defineProperty(element, 'mxsSetItemAlignment', {
           enumerable: true,
           writable: true,
           configurable: false,
-          value: () => {
-            element.itemAlignment.forEach(({ row, column, alignment }) => element.setItemAlignment(row, column, Alignment[alignment]));
+          value: (itemIndex) => {
+            if (itemIndex < element.getItemCount()) {
+              const cell = getItemCell(element.getItem(itemIndex));
+              if (cell !== undefined) {
+                element.itemAlignment
+                  .filter(({ row, column }) => row === cell.row && cell.column === column)
+                  .forEach(({ row, column, alignment }) => element.setItemAlignment(row, column, Alignment[alignment]));
+              }
+            }
           }
         });
     }

--- a/src/platform/lumin-runtime/elements/builders/linear-layout-builder.js
+++ b/src/platform/lumin-runtime/elements/builders/linear-layout-builder.js
@@ -7,10 +7,26 @@ import { Orientation } from '../../types/orientation.js';
 import { EnumProperty } from '../properties/enum-property.js';
 
 export class LinearLayoutBuilder extends PositionalLayoutBuilder {
-    constructor(){
+    constructor() {
         super();
 
         this._propertyDescriptors['orientation'] = new EnumProperty('orientation', 'setOrientation', true, Orientation, 'Orientation');
+
+        // itemAlignment
+        const itemAlignmentProperties = [
+            new PrimitiveTypeProperty('index', undefined, undefined, 'number'),
+            new EnumProperty('alignment', undefined, undefined, Alignment, 'Alignment')
+        ];
+
+        this._propertyDescriptors['itemAlignment'] = new ClassProperty('itemAlignment', 'setItemAlignment', false, itemAlignmentProperties);
+
+        // itemPadding
+        const itemPaddingProperties = [
+            new PrimitiveTypeProperty('index', undefined, undefined, 'number'),
+            new ArrayProperty('padding', undefined, undefined, 'vec4')
+        ];
+
+        this._propertyDescriptors['itemPadding'] = new ClassProperty('itemPadding', 'setItemPadding', false, itemPaddingProperties);
     }
 
     create(prism, properties) {
@@ -21,5 +37,15 @@ export class LinearLayoutBuilder extends PositionalLayoutBuilder {
         this.update(element, undefined, properties);
 
         return element;
+    }
+
+    setItemAlignment (element, oldProperties, newProperties) {
+        newProperties.itemAlignment
+          .forEach(({ index, alignment }) => element.setItemAlignment(index, Alignment[alignment]));
+    }
+
+    setItemPadding (element, oldProperties, newProperties) {
+        newProperties.itemPadding
+          .forEach(({ index, padding }) => element.setItemPadding(index, padding));
     }
 }

--- a/src/platform/lumin-runtime/elements/builders/linear-layout-builder.js
+++ b/src/platform/lumin-runtime/elements/builders/linear-layout-builder.js
@@ -34,41 +34,45 @@ export class LinearLayoutBuilder extends PositionalLayoutBuilder {
 
         const element = ui.UiLinearLayout.Create(prism);
 
-        Object.defineProperty(element, 'itemPadding', {
-            enumerable: true,
-            writable: true,
-            configurable: false,
-            value: []
-        });
-
-        Object.defineProperty(element, 'mxsUpdateItemPadding', {
-            enumerable: true,
-            writable: true,
-            configurable: false,
-            value: () => {
-              element.itemAlignment.forEach(({ index, padding }) => element.setItemPadding(index, padding));
-            }
-        });
-
-        Object.defineProperty(element, 'itemAlignment', {
-            enumerable: true,
-            writable: true,
-            configurable: false,
-            value: []
-        });
-
-        Object.defineProperty(element, 'mxsUpdateItemAlignment', {
-            enumerable: true,
-            writable: true,
-            configurable: false,
-            value: () => {
-              element.itemAlignment.forEach(({ index, alignment }) => element.setItemAlignment(index, Alignment[alignment]));
-            }
-        });
+        this._addCustomProperties(element);
 
         this.update(element, undefined, properties);
 
         return element;
+    }
+
+    _addCustomProperties (element) {
+        Object.defineProperty(element, 'itemPadding', {
+          enumerable: true,
+          writable: true,
+          configurable: false,
+          value: []
+        });
+
+        Object.defineProperty(element, 'mxsUpdateItemPadding', {
+          enumerable: true,
+          writable: true,
+          configurable: false,
+          value: () => {
+            element.itemPadding.forEach(({ index, padding }) => element.setItemPadding(index, padding));
+          }
+        });
+
+        Object.defineProperty(element, 'itemAlignment', {
+          enumerable: true,
+          writable: true,
+          configurable: false,
+          value: []
+        });
+
+        Object.defineProperty(element, 'mxsUpdateItemAlignment', {
+          enumerable: true,
+          writable: true,
+          configurable: false,
+          value: () => {
+            element.itemAlignment.forEach(({ index, alignment }) => element.setItemAlignment(index, Alignment[alignment]));
+          }
+        });
     }
 
     setItemAlignment (element, oldProperties, newProperties) {

--- a/src/platform/lumin-runtime/elements/builders/linear-layout-builder.js
+++ b/src/platform/lumin-runtime/elements/builders/linear-layout-builder.js
@@ -53,13 +53,13 @@ export class LinearLayoutBuilder extends PositionalLayoutBuilder {
           value: []
         });
 
-        Object.defineProperty(element, 'mxsUpdateItemPadding', {
+        Object.defineProperty(element, 'mxsSetItemPadding', {
           enumerable: true,
           writable: true,
           configurable: false,
-          value: () => {
-            element.itemPadding.forEach(({ index, padding }) => element.setItemPadding(index, padding));
-          }
+          value: (itemIndex) =>
+            element.itemPadding.filter(({ index }) => index == itemIndex )
+              .forEach(({ index, padding }) => element.setItemPadding(index, padding))
         });
 
         Object.defineProperty(element, 'itemAlignment', {
@@ -69,13 +69,13 @@ export class LinearLayoutBuilder extends PositionalLayoutBuilder {
           value: []
         });
 
-        Object.defineProperty(element, 'mxsUpdateItemAlignment', {
+        Object.defineProperty(element, 'mxsSetItemAlignment', {
           enumerable: true,
           writable: true,
           configurable: false,
-          value: () => {
-            element.itemAlignment.forEach(({ index, alignment }) => element.setItemAlignment(index, Alignment[alignment]));
-          }
+          value: (itemIndex) =>
+            element.itemAlignment.filter(({ index }) => index == itemIndex )
+              .forEach(({ index, alignment }) => element.setItemAlignment(index, Alignment[alignment]))
         });
     }
 

--- a/src/platform/lumin-runtime/elements/builders/linear-layout-builder.js
+++ b/src/platform/lumin-runtime/elements/builders/linear-layout-builder.js
@@ -3,8 +3,12 @@
 import { ui } from 'lumin';
 
 import { PositionalLayoutBuilder } from './positional-layout-builder.js';
-import { Orientation } from '../../types/orientation.js';
+import { ArrayProperty } from '../properties/array-property.js';
+import { ClassProperty } from '../properties/class-property.js';
 import { EnumProperty } from '../properties/enum-property.js';
+import { PrimitiveTypeProperty } from '../properties/primitive-type-property.js';
+import { Alignment } from '../../types/alignment.js';
+import { Orientation } from '../../types/orientation.js';
 
 export class LinearLayoutBuilder extends PositionalLayoutBuilder {
     constructor() {
@@ -76,12 +80,12 @@ export class LinearLayoutBuilder extends PositionalLayoutBuilder {
     }
 
     setItemAlignment (element, oldProperties, newProperties) {
-        newProperties.itemAlignment
-          .forEach(({ index, alignment }) => element.setItemAlignment(index, Alignment[alignment]));
+      this._setPropertyValue(element, oldProperties, newProperties, 'itemAlignment',
+        ({ index, alignment }) => element.setItemAlignment(index, Alignment[alignment]));
     }
 
     setItemPadding (element, oldProperties, newProperties) {
-        newProperties.itemPadding
-          .forEach(({ index, padding }) => element.setItemPadding(index, padding));
+      this._setPropertyValue(element, oldProperties, newProperties, 'itemPadding',
+        ({ index, padding }) => element.setItemPadding(index, padding));
     }
 }

--- a/src/platform/lumin-runtime/elements/builders/linear-layout-builder.js
+++ b/src/platform/lumin-runtime/elements/builders/linear-layout-builder.js
@@ -34,6 +34,38 @@ export class LinearLayoutBuilder extends PositionalLayoutBuilder {
 
         const element = ui.UiLinearLayout.Create(prism);
 
+        Object.defineProperty(element, 'itemPadding', {
+            enumerable: true,
+            writable: true,
+            configurable: false,
+            value: []
+        });
+
+        Object.defineProperty(element, 'mxsUpdateItemPadding', {
+            enumerable: true,
+            writable: true,
+            configurable: false,
+            value: () => {
+              element.itemAlignment.forEach(({ index, padding }) => element.setItemPadding(index, padding));
+            }
+        });
+
+        Object.defineProperty(element, 'itemAlignment', {
+            enumerable: true,
+            writable: true,
+            configurable: false,
+            value: []
+        });
+
+        Object.defineProperty(element, 'mxsUpdateItemAlignment', {
+            enumerable: true,
+            writable: true,
+            configurable: false,
+            value: () => {
+              element.itemAlignment.forEach(({ index, alignment }) => element.setItemAlignment(index, Alignment[alignment]));
+            }
+        });
+
         this.update(element, undefined, properties);
 
         return element;

--- a/src/platform/lumin-runtime/elements/builders/linear-layout-builder.js
+++ b/src/platform/lumin-runtime/elements/builders/linear-layout-builder.js
@@ -55,7 +55,7 @@ export class LinearLayoutBuilder extends PositionalLayoutBuilder {
 
         Object.defineProperty(element, 'mxsSetItemPadding', {
           enumerable: true,
-          writable: true,
+          writable: false,
           configurable: false,
           value: (itemIndex) =>
             element.itemPadding.filter(({ index }) => index == itemIndex )
@@ -71,7 +71,7 @@ export class LinearLayoutBuilder extends PositionalLayoutBuilder {
 
         Object.defineProperty(element, 'mxsSetItemAlignment', {
           enumerable: true,
-          writable: true,
+          writable: false,
           configurable: false,
           value: (itemIndex) =>
             element.itemAlignment.filter(({ index }) => index == itemIndex )

--- a/src/platform/lumin-runtime/elements/builders/positional-layout-builder.js
+++ b/src/platform/lumin-runtime/elements/builders/positional-layout-builder.js
@@ -16,12 +16,7 @@ export class PositionalLayoutBuilder extends LayoutBuilder {
     }
 
     _setPropertyValue (element, oldProperties, newProperties, propertyName, setter) {
-        const count = element.getItemCount();
-        const items = newProperties[propertyName];
-
-        element[propertyName] = items;
-
-        items.filter(({ index }) => index < count)
-          .forEach(value => setter(value));
+        element[propertyName] = newProperties[propertyName];
+        element[propertyName].forEach(value => setter(value));
     }
 }

--- a/src/platform/lumin-runtime/elements/builders/positional-layout-builder.js
+++ b/src/platform/lumin-runtime/elements/builders/positional-layout-builder.js
@@ -12,8 +12,6 @@ export class PositionalLayoutBuilder extends LayoutBuilder {
 
         this._propertyDescriptors['defaultItemAlignment'] = new EnumProperty('defaultItemAlignment', 'setDefaultItemAlignment', true, Alignment, 'Alignment');
         this._propertyDescriptors['defaultItemPadding'] = new ArrayProperty('defaultItemPadding', 'setDefaultItemPadding', true, 'vec4');
-        this._propertyDescriptors['itemAlignment'] = new EnumProperty('itemAlignment', 'setItemAlignment', true, Alignment, 'Alignment');
-        this._propertyDescriptors['itemPadding'] = new ArrayProperty('itemPadding', 'setItemPadding', true, 'vec4');
         this._propertyDescriptors['skipInvisibleItems'] = new PrimitiveTypeProperty('skipInvisibleItems', 'setSkipInvisibleItems', true, 'boolean');
     }
 }

--- a/src/platform/lumin-runtime/elements/builders/positional-layout-builder.js
+++ b/src/platform/lumin-runtime/elements/builders/positional-layout-builder.js
@@ -14,4 +14,14 @@ export class PositionalLayoutBuilder extends LayoutBuilder {
         this._propertyDescriptors['defaultItemPadding'] = new ArrayProperty('defaultItemPadding', 'setDefaultItemPadding', true, 'vec4');
         this._propertyDescriptors['skipInvisibleItems'] = new PrimitiveTypeProperty('skipInvisibleItems', 'setSkipInvisibleItems', true, 'boolean');
     }
+
+    _setPropertyValue (element, oldProperties, newProperties, propertyName, setter) {
+        const count = element.getItemCount();
+        const items = newProperties[propertyName];
+
+        element[propertyName] = items;
+
+        items.filter(({ index }) => index < count)
+          .forEach(value => setter(value));
+    }
 }

--- a/src/platform/lumin-runtime/elements/properties/class-property.js
+++ b/src/platform/lumin-runtime/elements/properties/class-property.js
@@ -9,12 +9,18 @@ export class ClassProperty extends PropertyDescriptor {
         this._properties = properties;
     }
 
-    validate(value) {
-        for (const property of this._properties) {
-            property.validate( value[property.Name] );
-        }
+    _validate (value) {
+      this._properties.forEach(property => property.validate(value[property.Name]));
+    }
 
-        return true;
+    validate (value) {
+      if (Array.isArray(value)) {
+        value.forEach(item => this._validate(item));
+      } else {
+        this._validate(value);
+      }
+
+      return true;
     }
 
     tsType() {

--- a/src/platform/lumin-runtime/platform-factory.js
+++ b/src/platform/lumin-runtime/platform-factory.js
@@ -190,13 +190,16 @@ export class PlatformFactory extends NativeFactory {
           parent.addItem(child, padding, itemAlignment);
         } else {
           parent.addItem(child, padding);
+          parent.mxsSetItemAlignment(parent.getItemCount() - 1);
         }
       } else {
         parent.addItem(child);
+
+        // Should set the alignment and padding after adding items completes !
+        const index = parent.getItemCount() - 1;
+        parent.mxsSetItemAlignment(index);
+        parent.mxsSetItemPadding(index);
       }
-      // Should update the alignment and padding after adding items completes !
-      parent.mxsUpdateItemAlignment();
-      parent.mxsUpdateItemPadding();
     } else if (parent instanceof ui.UiSlider) {
       if (child instanceof TransformNode) {
         if (child.offset !== undefined) {

--- a/src/platform/lumin-runtime/platform-factory.js
+++ b/src/platform/lumin-runtime/platform-factory.js
@@ -194,6 +194,9 @@ export class PlatformFactory extends NativeFactory {
       } else {
         parent.addItem(child);
       }
+      // Should update the alignment and padding after adding items completes !
+      parent.mxsUpdateItemAlignment();
+      parent.mxsUpdateItemPadding();
     } else if (parent instanceof ui.UiSlider) {
       if (child instanceof TransformNode) {
         if (child.offset !== undefined) {


### PR DESCRIPTION
This PR adds:
1. Support for property of type array of objects
```
<LinearLayout
    localPosition={[-0.5, 0.5, 0]}
    width={0.5}
    height={0.8}
    itemPadding={[
        {index: 0, padding: [0, 0, 0, 0   ]},
        {index: 1, padding: [0, 0, 0, 0.05]},
        {index: 2, padding: [0, 0, 0, 0.1 ]},
        {index: 3, padding: [0, 0, 0, 0.15]}
    ]}
>
    <Text textSize={0.1 } text='Ganymede' textColor={[255, 165, 0, 0.8]} />
</LinearLayout>
```

2. Updated implementation of `itemAlignment` and `itemPadding` for `LinearLayout` and `GridLayout`.
