### PR TITLE
Add support for subscribing handlers for server events

### DIFF
--- a/src/platform/lumin-runtime/controllers/app-prism-controller.js
+++ b/src/platform/lumin-runtime/controllers/app-prism-controller.js
@@ -1,7 +1,8 @@
 // Copyright (c) 2019 Magic Leap, Inc. All Rights Reserved
 
+import log, { MessageSeverity } from '../../../util/logger.js';
 import { PrismController } from 'lumin';
-import { ReactMagicScript } from '../../../react-magic-script/react-magic-script.js'
+import { ReactMagicScript } from '../../../react-magic-script/react-magic-script.js';
 
 import { ControlPose3DofInputEventData } from '../types/event-data/control-pose-3dof-Input-event-data.js';
 import { ControlPose6DofInputEventData } from '../types/event-data/control-pose-6dof-input-event-data.js';
@@ -16,126 +17,142 @@ import { UiEventData } from '../types/event-data/ui-event-data.js';
 import { VideoEventData } from '../types/event-data/video-event-data.js';
 
 export class AppPrismController extends PrismController {
-    constructor(appComponent) {
-      super();
-      this._app = appComponent;
-      this._containers = new WeakMap();
+  constructor (appComponent) {
+    super();
+    this._app = appComponent;
+    this._containers = new WeakMap();
 
-      this._eventHandlers = {
-        onEvent: [],
-        onUpdate: []
-      };
+    this._eventHandlers = {
+      onEvent: [],
+      onUpdate: []
+    };
 
-      this._eventTypes = [
-        ControlPose3DofInputEventData,
-        ControlPose6DofInputEventData,
-        ControlTouchPadInputEventData,
-        EyeTrackingEventData,
-        GestureInputEventData,
-        InputEventData,
-        KeyInputEventData,
-        RayCastEventData,
-        SelectionEventData,
-        UiEventData,
-        VideoEventData
-      ];
+    this._eventTypes = [
+      ControlPose3DofInputEventData,
+      ControlPose6DofInputEventData,
+      ControlTouchPadInputEventData,
+      EyeTrackingEventData,
+      GestureInputEventData,
+      InputEventData,
+      KeyInputEventData,
+      RayCastEventData,
+      SelectionEventData,
+      UiEventData,
+      VideoEventData
+    ];
+
+    this._eventTypes.forEach(eventDataConstructor => {
+      this._eventHandlers[this._getEventTypeName(eventDataConstructor.name)] = [];
+    });
+  }
+
+  getRootNodeName (componentName) {
+    return componentName === undefined
+      ? '__root_prism_controller_'
+      : `__root_prism_controller_${componentName.trim().replace(' ', '_')}`;
+  }
+
+  findChild (nodeName) {
+    const root = this.getRoot();
+    return root.getName() === nodeName ? root : root.findChild(nodeName);
+  }
+
+  getContainer (nodeName) {
+    const parent = nodeName === undefined
+      ? this.getRoot()
+      : this.findChild(nodeName);
+
+    let container = this._containers[parent];
+
+    if (container === undefined) {
+      container = { parent: parent, controller: this };
+      this._containers[parent] = container;
     }
 
-    getRootNodeName(componentName) {
-      return componentName === undefined
-        ? '__root_prism_controller_'
-        : `__root_prism_controller_${componentName.trim().replace(' ', '_')}`;
+    return container;
+  }
+
+  onAttachPrism (prism) {
+    const rootNodeName = this.getRootNodeName(this._app.props.name);
+    this.getRoot().setName(rootNodeName);
+
+    try {
+      ReactMagicScript.render(this._app, this.getContainer());
+    } catch (error) {
+      log(`${error.name} - ${error.message}\n${error.stack}`, MessageSeverity.exception);
+      throw error;
     }
+  }
 
-    findChild(nodeName) {
-      const root = this.getRoot();
-      return root.getName() === nodeName ? root : root.findChild(nodeName);
+  onDetachPrism (prism) {
+    this.deleteSceneGraph();
+  }
+
+  addListener (nodeId, event, eventHandlerCallback) {
+    const handlers = this._eventHandlers[event];
+    if (handlers !== undefined) {
+      handlers.push({ id: nodeId, handler: eventHandlerCallback });
+    } else {
+      throw TypeError(`Event ${event} is not supported by the controller`);
     }
+  }
 
-    getContainer(nodeName) {
-        const parent = nodeName === undefined
-            ? this.getRoot()
-            : this.findChild(nodeName);
-
-        let container = this._containers[parent];
-
-        if (container === undefined) {
-            container = { parent: parent, controller: this };
-            this._containers[parent] = container;
-        }
-
-        return container;
-    }
-
-    onAttachPrism(prism) {
-        const rootNodeName = this.getRootNodeName(this._app.props.name);
-        this.getRoot().setName(rootNodeName);
-
-        try {
-            ReactMagicScript.render(this._app, this.getContainer());
-        } catch (error) {
-            console.log(`${error.name} - ${error.message}\n${error.stack}`);
-            throw error;
-        }
-    }
-
-    onDetachPrism(prism) {
-        this.deleteSceneGraph();
-    }
-
-    addListener (nodeId, event, eventHandlerCallback) {
-      const handlers = this._eventHandlers[event];
-      if (handlers !== undefined) {
-        handlers.push({ id: nodeId, handler: eventHandlerCallback });
-      } else {
-        throw TypeError(`Event ${event} is not supported by the controller`);
+  removeListener (nodeId, event, eventHandlerCallback) {
+    const handlers = this._eventHandlers[event];
+    if (handlers !== undefined) {
+      const index = handlers.findIndex(subscriber => subscriber.id === nodeId && subscriber.handler === eventHandlerCallback);
+      if (index !== -1) {
+        handlers.splice(index, 1);
       }
+    } else {
+      throw TypeError(`Event ${event} is not supported by the controller`);
+    }
+  }
+
+  onEvent (event) {
+    const eventData = this._getEventDataByEventType(event);
+
+    let handlers = this._eventHandlers[this._getEventTypeName(eventData.constructor.name)];
+
+    if (!Array.isArray(handlers)) {
+      handlers = this._eventHandlers.onEvent;
     }
 
-    removeListener (nodeId, event, eventHandlerCallback) {
-      const handlers = this._eventHandlers[event];
-      if (handlers !== undefined) {
-        const index = handlers.findIndex(subscriber => subscriber.id === nodeId && subscriber.handler === eventHandlerCallback);
-        if (index !== -1) {
-          handlers.splice(index, 1);
-        }
-      } else {
-        throw TypeError(`Event ${event} is not supported by the controller`);
+    let eventIsConsumed = false;
+
+    for (let subscriber of handlers) {
+      if (eventIsConsumed === true) {
+        break;
       }
-    }
 
-    onEvent (event) {
-      const eventData = this._getEventDataByEventType(event);
-      let eventIsConsumed = false;
-
-      for (let subscriber of this._eventHandlers.onEvent) {
-        if (eventIsConsumed === true) {
-          break;
-        }
-
-        if (typeof event.getAffectedNodeId === 'function') {
-          if (subscriber.id === event.getAffectedNodeId()) {
-            eventIsConsumed = subscriber.handler(eventData);
-          }
-        } else {
+      if (typeof event.getAffectedNodeId === 'function') {
+        if (subscriber.id === event.getAffectedNodeId()) {
           eventIsConsumed = subscriber.handler(eventData);
         }
+      } else {
+        eventIsConsumed = subscriber.handler(eventData);
       }
-
-      return eventIsConsumed;
     }
 
-    onUpdate (delta) {
-      this._eventHandlers.onUpdate
-        .forEach(subscriber => subscriber.handler(delta));
-    }
+    return eventIsConsumed;
+  }
 
-    _getEventDataByEventType (eventData) {
-      const eventConstructor = this._eventTypes
-        .find(eventType => eventType.isSupported(eventData));
+  onUpdate (delta) {
+    this._eventHandlers.onUpdate
+      .forEach(subscriber => subscriber.handler(delta));
+  }
 
-      return eventConstructor === undefined
-        ? eventData
-        : new eventConstructor(eventData);
-    }
+  _getEventDataByEventType (eventData) {
+    const eventConstructor = this._eventTypes
+      .find(eventType => eventType.isSupported(eventData));
+
+    return eventConstructor === undefined
+      ? eventData
+      : new eventConstructor(eventData);
+  }
+
+  _getEventTypeName (eventDataTypeName) {
+    // Remove suffix 'Data' from the event data type name
+    return `on${eventDataTypeName.slice(0, -4)}`;
+  }
 }

--- a/src/platform/lumin-runtime/types/controller-events.js
+++ b/src/platform/lumin-runtime/types/controller-events.js
@@ -1,4 +1,15 @@
 export const ControllerEvents = {
   'onEvent': { eventName: 'onEvent' },
-  'onUpdateLoop': { eventName: 'onUpdate' }
+  'onUpdateLoop': { eventName: 'onUpdate' },
+  'onControlPose3DofInputEvent': { eventName: 'onControlPose3DofInputEvent' },
+  'onControlPose6DofInputEvent': { eventName: 'onControlPose6DofInputEvent' },
+  'onControlTouchPadInputEvent': { eventName: 'onControlTouchPadInputEvent' },
+  'onEyeTrackingEvent': { eventName: 'onEyeTrackingEvent' },
+  'onGestureInputEvent': { eventName: 'onGestureInputEvent' },
+  'onInputEvent': { eventName: 'onInputEvent' },
+  'onKeyInputEvent': { eventName: 'onKeyInputEvent' },
+  'onRayCastEvent': { eventName: 'onRayCastEvent' },
+  'onSelectionEvent': { eventName: 'onSelectionEvent' },
+  'onUiEvent': { eventName: 'onUiEvent' },
+  'onVideoEvent': { eventName: 'onVideoEvent' }
 };


### PR DESCRIPTION
Instead of moving EventData type definitions to `magic-script-components` and asking the developer to use `instaceof`, we are providing support for subscribing to each event. In case this event is not supported yet it will be routed to `onEvent`:

```
<Content
  name="rootNode"
  onUpdateLoop={ this.updateLoopHandler }
  onEvent={ this.eventGenericHandler }
  onControlPose3DofInputEvent={ this.ononControlPose3DofInputEventHandler }
  onControlPose6DofInputEvent={ this.onControlPose6DofInputEventHandler }
  onControlTouchPadInputEvent={ this.onControlTouchPadInputEventHandler }
  onEyeTrackingEvent={ this.onEyeTrackingEventHandler }
  onGestureInputEvent={ this.onGestureInputEventHandler }
  onInputEvent={ this.onInputEventHandler }
  onKeyInputEvent={ this.onKeyInputEventHandler }
  onRayCastEvent={ this.onRayCastEventHandler }
  onSelectionEvent={ this.onSelectionEventHandler }
  onUiEvent={ this.onUiEventHandler }
  onVideoEvent={ this.onVideoEventHandler }
>
 ...
</Content>
```