### PR TITLE
Fix bug based on the wrong property name

### DIFF
--- a/src/platform/lumin-runtime/elements/builders/audio-builder.js
+++ b/src/platform/lumin-runtime/elements/builders/audio-builder.js
@@ -185,7 +185,7 @@ export class AudioBuilder extends TransformBuilder {
     }
 
     setSpatialSoundDistance(element, oldProperties, newProperties) {
-        newProperties.setSpatialSoundDistance
+        newProperties.spatialSoundDistance
             .forEach(({ channel, minDistance, maxDistance, rolloffFactor }) => {
                 const distanceProperties = this._getSpatialSoundDistanceProperties(minDistance, maxDistance, rolloffFactor);
 


### PR DESCRIPTION
Thank you for your contribution to MagicScript Project.
Before submitting this PR, please make sure:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved terminology
- [ ] You have added unit tests

Change: replace `setSpatialSoundDistance` with `spatialSoundDistance`.