### PR TITLE
Fix mat4 type declaration to be a flat array

### DIFF
--- a/src/platform/lumin-runtime/elements/properties/array-property.js
+++ b/src/platform/lumin-runtime/elements/properties/array-property.js
@@ -30,7 +30,10 @@ export class ArrayProperty extends PropertyDescriptor {
             vec3: '[number, number, number]',
             vec4: '[number, number, number, number]',
             quat: 'vec4',
-            mat4: '[vec4, vec4, vec4, vec4]'
+            mat4: '[number, number, number, number, ' +
+                   'number, number, number, number, ' +
+                   'number, number, number, number, ' +
+                   'number, number, number, number]'
         }
     }
 }

--- a/src/platform/lumin-runtime/elements/properties/property-descriptor.js
+++ b/src/platform/lumin-runtime/elements/properties/property-descriptor.js
@@ -6,7 +6,7 @@ const ArrayLengthByType = {
     'vec3': 3,
     'vec4': 4,
     'quat': 4,
-    'mat4': 4
+    'mat4': 16
 }
 
 export class PropertyDescriptor {
@@ -84,8 +84,7 @@ export class PropertyDescriptor {
             }
 
             if (   this.hasValue(arrayType)
-                && value.length !== ArrayLengthByType[arrayType]
-                && value.length !== 16) {
+                && value.length !== ArrayLengthByType[arrayType]) {
                 throw new TypeError(`Parameter ${JSON.stringify(value)} should be ${arrayType} value`);
             }
         }


### PR DESCRIPTION
Also, fix ArrayLengthByType for 'mat4' to be 16 and remove hard-coded check for size 16 arrays that was masking incorrect length definition.

Thank you for your contribution to MagicScript Project.
Before submitting this PR, please make sure:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved terminology
- [ ] You have added unit tests
