### PR TITLE
Unsubscribe event handlers

### DIFF
--- a/src/platform/lumin-runtime/elements/builders/prism-builder.js
+++ b/src/platform/lumin-runtime/elements/builders/prism-builder.js
@@ -40,6 +40,13 @@ export class PrismBuilder extends ElementBuilder {
       value: (child) => logError('Prism is not supposed to add children !')
     });
 
+    Object.defineProperty(prism, 'onDestroyHandlerId', {
+      enumerable: true,
+      writable: true,
+      configurable: false,
+      value: undefined
+    });
+
     // Filter out 'size' property
     const { size, ...unapplied } = properties;
     this.update(prism, undefined, unapplied, app);

--- a/src/platform/lumin-runtime/mxs-base-app.js
+++ b/src/platform/lumin-runtime/mxs-base-app.js
@@ -68,10 +68,25 @@ export class MxsBaseApp {
     this._prismControllers.push(controller);
 
     executor.callNativeAction(prism, 'setPrismController', controller);
+
+    const onDestroyHandlerId = executor.callNativeFunction(prism, 'onDestroyEventSub', (closingPrism) => {
+      const prismId = executor.callNativeFunction(closingPrism, 'getPrismId');
+      this._prisms = this._prisms.filter(p => executor.callNativeFunction(p, 'getPrismId') !== prismId);
+
+      if (!executor.callNativeFunction(closingPrism, 'onDestroyEventUnsub', onDestroyHandlerId)) {
+        logWarning('Failed to unsubscribe from Prism.onDestroyEvent');
+      }
+    });
+
     return prism;
   }
 
   removePrism(prism, app) {
+    const prismId = executor.callNativeFunction(prism, 'getPrismId');
+    if (this._prisms.every(p => executor.callNativeFunction(p, 'getPrismId') !== prismId)) {
+      return;
+    }
+
     const controller = executor.callNativeFunction(prism, 'getPrismController');
 
     this._prismControllers = this._prismControllers.filter(c => c !== controller);

--- a/src/platform/lumin-runtime/mxs-base-app.js
+++ b/src/platform/lumin-runtime/mxs-base-app.js
@@ -79,6 +79,8 @@ export class MxsBaseApp {
 
     executor.callNativeAction(controller, 'deleteSceneGraph');
     executor.callNativeAction(prism, 'setPrismController', null);
-    executor.callNativeAction(app, 'deletePrism', prism);
+
+    // Set Prism deletion after the current call completes.
+    setTimeout(() => executor.callNativeAction(app, 'deletePrism', prism), 0)
   }
 }

--- a/src/platform/lumin-runtime/platform-factory.js
+++ b/src/platform/lumin-runtime/platform-factory.js
@@ -30,6 +30,9 @@ export class PlatformFactory extends NativeFactory {
     this.elementBuilders = {};
     this.controllerBuilders = {};
 
+    // The member '_eventCallbackData' should store the callbackId for each node for each prism
+    // PlatformFactory uses the callbackIds to unsubscribe all the callbacks when closing the prism
+    // Map structure: 
     // { prismId: { nodeId: { eventName: callbackId } }
     //
     // example:
@@ -71,11 +74,8 @@ export class PlatformFactory extends NativeFactory {
   }
 
   _getCallbackDataPerNode (node) {
-    const prismData = this._eventCallbackData[executor.callNativeFunction(node, 'getPrismId')];
-
-    return prismData
-      ? prismData[executor.callNativeFunction(node, 'getNodeId')] || {}
-      : {};
+    const prismData = this._getCallbackDataPerPrism(executor.callNativeFunction(node, 'getPrismId'));
+    return prismData[executor.callNativeFunction(node, 'getNodeId')] || {};
   }
 
   _getCallbackDataPerPrism (prism) {

--- a/src/platform/lumin-runtime/platform-factory.js
+++ b/src/platform/lumin-runtime/platform-factory.js
@@ -69,10 +69,6 @@ export class PlatformFactory extends NativeFactory {
 
     this._eventCallbackData[prismId][nodeId][eventName] = callbackId;
   }
-  
-  _getCallbackDataPerPrism (prism) {
-    return this._eventCallbackData[executor.callNativeFunction(prism, 'getPrismId')] || {};
-  }
 
   _getCallbackDataPerNode (node) {
     const prismData = this._eventCallbackData[executor.callNativeFunction(node, 'getPrismId')];
@@ -80,6 +76,10 @@ export class PlatformFactory extends NativeFactory {
     return prismData
       ? prismData[executor.callNativeFunction(node, 'getNodeId')] || {}
       : {};
+  }
+
+  _getCallbackDataPerPrism (prism) {
+    return this._eventCallbackData[executor.callNativeFunction(prism, 'getPrismId')] || {};
   }
 
   setComponentEvents (element, properties, controller) {
@@ -494,6 +494,10 @@ export class PlatformFactory extends NativeFactory {
 
   _removePrismFromScene (scene, prism) {
     scene.removeChild(prism);
+
+    if (prism.onDestroyHandlerId) {
+      executor.callNativeAction(prism, 'onDestroyEventUnsub', prism.onDestroyHandlerId);
+    }
 
     const prismNodeCallbackData = this._getCallbackDataPerPrism(prism);
     for (const [nodeId, nodeEventHandlerIds] of Object.entries(prismNodeCallbackData)) {


### PR DESCRIPTION
- [x] Your code builds clean without any errors or warnings
- [x] You are using approved terminology
- [ ] You have added unit tests

1. PlatformFactory unsubscribes all the event handlers, subscribed for node events, when remove prism has been requested.
2. MxsBaseApp checks if the requested prism for deletion has been already removed before attempting to delete the prism. When prism has been closed using the bumper, the MxsBaseApp will remove the prism from the list of created prisms.
3. Store the Prism's `onDestroyHandlerId` as property of the JavaScript prism object.
