### PR TITLE
Add BaseApp events support

### DIFF
--- a/src/platform/lumin-runtime/elements/builders/scene-builder.js
+++ b/src/platform/lumin-runtime/elements/builders/scene-builder.js
@@ -2,7 +2,16 @@ import { ElementBuilder } from './element-builder.js';
 import { MxsScene } from '../mxs-scene.js';
 
 export class SceneBuilder extends ElementBuilder {
-    create() {
+    create(app, properties) {
+
+        this._callOnAppStart(app, properties.onAppStart);
+
         return new MxsScene();
+    }
+
+    _callOnAppStart (app, onAppStartHandler) {
+        if (onAppStartHandler && typeof onAppStartHandler === 'function') {
+            onAppStartHandler(app.OnAppStartData);
+        }
     }
 }

--- a/src/platform/lumin-runtime/elements/builders/scene-builder.js
+++ b/src/platform/lumin-runtime/elements/builders/scene-builder.js
@@ -3,6 +3,7 @@ import { MxsScene } from '../mxs-scene.js';
 
 export class SceneBuilder extends ElementBuilder {
     constructor() {
+        super();
         this._appEventNames = ['onAppPause', 'onAppResume'];
     }
 

--- a/src/platform/lumin-runtime/elements/builders/scene-builder.js
+++ b/src/platform/lumin-runtime/elements/builders/scene-builder.js
@@ -13,28 +13,22 @@ export class SceneBuilder extends ElementBuilder {
         }
     }
 
-    _callAppFunction(app, functionName, ...args) {
-        app[functionName](...args);
-    }
-
-    _updateListeners(app, oldProperties, newProperties, updateAction, predicate) {
+    _updateListeners(app, oldProperties, newProperties, updateAction, selector) {
         this._appEventNames.forEach(eventName => {
-            if (predicate(oldProperties[eventName], newProperties[eventName])) {
-                this._callAppFunction(app, updateAction, eventName, oldProperties.onAppPause);
-            }
+            app[updateAction](eventName, selector(oldProperties[eventName], newProperties[eventName]));
         });
     }
 
     create(app, properties) {
         this._callOnAppStart(app, properties.onAppStart);
 
-        this._updateListeners(app, {}, properties, 'addListener', (oldValue, newValue) => !oldValue && newValue);
+        this._updateListeners(app, {}, properties, 'addListener', (oldValue, newValue) => newValue);
 
         return new MxsScene();
     }
 
     update (prism, oldProperties, newProperties, app) {
-        this._updateListeners(app, oldProperties, newProperties, 'removeListener', (oldValue, newValue) => oldValue && !newValue);
-        this._updateListeners(app,  oldProperties, newProperties, 'addListener', (oldValue, newValue) => !oldValue && newValue);
+        this._updateListeners(app, oldProperties, newProperties, 'removeListener', (oldValue, newValue) => oldValue);
+        this._updateListeners(app,  oldProperties, newProperties, 'addListener', (oldValue, newValue) => newValue);
     }
 }

--- a/src/platform/lumin-runtime/elements/builders/scene-builder.js
+++ b/src/platform/lumin-runtime/elements/builders/scene-builder.js
@@ -2,16 +2,38 @@ import { ElementBuilder } from './element-builder.js';
 import { MxsScene } from '../mxs-scene.js';
 
 export class SceneBuilder extends ElementBuilder {
-    create(app, properties) {
-
-        this._callOnAppStart(app, properties.onAppStart);
-
-        return new MxsScene();
+    constructor() {
+        this._appEventNames = ['onAppPause', 'onAppResume'];
     }
 
     _callOnAppStart (app, onAppStartHandler) {
         if (onAppStartHandler && typeof onAppStartHandler === 'function') {
             onAppStartHandler(app.OnAppStartData);
         }
+    }
+
+    _callAppFunction(app, functionName, ...args) {
+        app[functionName](...args);
+    }
+
+    _updateListeners(app, oldProperties, newProperties, updateAction, predicate) {
+        this._appEventNames.forEach(eventName => {
+            if (predicate(oldProperties[eventName], newProperties[eventName])) {
+                this._callAppFunction(app, updateAction, eventName, oldProperties.onAppPause);
+            }
+        });
+    }
+
+    create(app, properties) {
+        this._callOnAppStart(app, properties.onAppStart);
+
+        this._updateListeners(undefined, {}, properties, 'addListener', (oldValue, newValue) => !oldValue && newValue);
+
+        return new MxsScene();
+    }
+
+    update (prism, oldProperties, newProperties, app) {
+        this._updateListeners(app, oldProperties, newProperties, 'removeListener', (oldValue, newValue) => oldValue && !newValue);
+        this._updateListeners(app,  oldProperties, newProperties, 'addListener', (oldValue, newValue) => !oldValue && newValue);
     }
 }

--- a/src/platform/lumin-runtime/elements/builders/scene-builder.js
+++ b/src/platform/lumin-runtime/elements/builders/scene-builder.js
@@ -28,7 +28,7 @@ export class SceneBuilder extends ElementBuilder {
     create(app, properties) {
         this._callOnAppStart(app, properties.onAppStart);
 
-        this._updateListeners(undefined, {}, properties, 'addListener', (oldValue, newValue) => !oldValue && newValue);
+        this._updateListeners(app, {}, properties, 'addListener', (oldValue, newValue) => !oldValue && newValue);
 
         return new MxsScene();
     }

--- a/src/platform/lumin-runtime/mxs-base-app.js
+++ b/src/platform/lumin-runtime/mxs-base-app.js
@@ -11,9 +11,34 @@ export class MxsBaseApp {
       this._app = appComponent;
       this._prisms = [];
       this._prismControllers = [];
+      this._eventHandlers = {
+        // onAppStart: [], // The rendering process hasn't started yet
+        onAppPause: [],
+        onAppResume: [],
+        // onDeviceActive: [],
+        // onDeviceReality: [],
+        // onDeviceStandby: [],
+        // onDeviceStart: [],
+        // onDeviceStop: []
+      };
+
+      this._onAppStartData;
   }
 
-  onAppStart(arg) {
+  get OnAppStartData () {
+    return this._onAppStartData;
+  }
+
+  onAppStart(args) {
+    this._onAppStartData = { 
+      initArgs: args,
+      isImageTrackingReady: this.isImageTrackingReady(),
+      isInternetConnected: this.isInternetConnected(),
+      isShareableApp: this.isShareableApp(),
+      isWiFiConnected: this.isWiFiConnected(),
+      isWiFiEnabled: this.isWiFiEnabled(),
+    };
+
     const container = {
       controller: {
         getRoot: () => ({ addChild: (child) => logInfo('App container - adding child (scene)') })

--- a/src/platform/lumin-runtime/mxs-base-app.js
+++ b/src/platform/lumin-runtime/mxs-base-app.js
@@ -31,7 +31,7 @@ export class MxsBaseApp {
 
   onAppStart(args) {
     this._onAppStartData = { 
-      initArgs: args.getUri(),
+      uri: args.getUri(),
       isInternetConnected: typeof this.isInternetConnected === 'function' ? this.isInternetConnected() : undefined,
       isWiFiConnected: typeof this.isWiFiConnected === 'function' ? this.isWiFiConnected() : undefined,
       isWiFiEnabled: typeof this.isWiFiEnabled === 'function' ? this.isWiFiEnabled() : undefined,

--- a/src/platform/lumin-runtime/mxs-base-app.js
+++ b/src/platform/lumin-runtime/mxs-base-app.js
@@ -45,11 +45,11 @@ export class MxsBaseApp {
   }
 
   onAppPause() {
-    this._eventHandlers.onAppPause.forEach(handler => handler(...args));
+    this._eventHandlers.onAppPause.forEach(handler => handler());
   }
 
   onAppResume() {
-    this._eventHandlers.onAppResume.forEach(handler => handler(...args));
+    this._eventHandlers.onAppResume.forEach(handler => handler());
   }
 
   updateLoop(delta) {

--- a/src/platform/lumin-runtime/mxs-base-app.js
+++ b/src/platform/lumin-runtime/mxs-base-app.js
@@ -31,12 +31,11 @@ export class MxsBaseApp {
 
   onAppStart(args) {
     this._onAppStartData = { 
-      initArgs: args,
-      isImageTrackingReady: this.isImageTrackingReady(),
-      isInternetConnected: this.isInternetConnected(),
-      isShareableApp: this.isShareableApp(),
-      isWiFiConnected: this.isWiFiConnected(),
-      isWiFiEnabled: this.isWiFiEnabled(),
+      initArgs: args.getUri(),
+      isInternetConnected: typeof this.isInternetConnected === 'function' ? this.isInternetConnected() : undefined,
+      isWiFiConnected: typeof this.isWiFiConnected === 'function' ? this.isWiFiConnected() : undefined,
+      isWiFiEnabled: typeof this.isWiFiEnabled === 'function' ? this.isWiFiEnabled() : undefined,
+      isShareableApp: typeof this.isShareableApp === 'function' ? this.isShareableApp() : undefined
     };
 
     const container = {

--- a/src/platform/lumin-runtime/mxs-base-app.js
+++ b/src/platform/lumin-runtime/mxs-base-app.js
@@ -26,29 +26,6 @@ export class MxsBaseApp {
     return this._onAppStartData;
   }
 
-  addListener(eventName, eventHandler) {
-    if (typeof eventHandler === 'function') {
-      const handlers = this._eventHandlers[eventName];
-      if (handlers) {
-        handlers.push(eventHandler);
-      } else {
-        logWarning(`Provided event ${eventName} is not supported`);
-      }
-    } else {
-      logWarning(`Provided event handler for ${eventName} is not a function`);
-    }
-  }
-
-  removeListener(eventName, eventHandler) {
-    const handlers = this._eventHandlers[eventName];
-    if (handlers) {
-      const index = handlers.indexOf(eventHandler);
-      handlers.splice(index, 1);
-    } else {
-      logWarning(`Provided event ${eventName} is not supported`);
-    }
-  }
-
   onAppStart(args) {
     this._onAppStartData = { 
       uri: args.getUri(),
@@ -149,5 +126,28 @@ export class MxsBaseApp {
 
     // Set Prism deletion after the current call completes.
     setTimeout(() => executor.callNativeAction(app, 'deletePrism', prism), 0)
+  }
+
+  addListener(eventName, eventHandler) {
+    if (typeof eventHandler === 'function') {
+      const handlers = this._eventHandlers[eventName];
+      if (handlers) {
+        handlers.push(eventHandler);
+      } else {
+        logWarning(`Provided event ${eventName} is not supported`);
+      }
+    }
+  }
+
+  removeListener(eventName, eventHandler) {
+    const handlers = this._eventHandlers[eventName];
+    if (handlers) {
+      const index = handlers.indexOf(eventHandler);
+      if (index > -1 ) {
+        handlers.splice(index, 1);
+      }
+    } else {
+      logWarning(`Provided event ${eventName} is not supported`);
+    }
   }
 }

--- a/src/platform/lumin-runtime/mxs-immersive-app.js
+++ b/src/platform/lumin-runtime/mxs-immersive-app.js
@@ -24,6 +24,14 @@ export class MxsImmersiveApp extends ImmersiveApp {
     this._baseApp.onAppStart(arg);
   }
 
+  onAppPause() {
+    this._baseApp.onAppPause();
+  }
+
+  onAppResume() {
+    this._baseApp.onAppResume();
+  }
+
   updateLoop(delta) {
     return this._baseApp.updateLoop(delta);
   }
@@ -42,5 +50,13 @@ export class MxsImmersiveApp extends ImmersiveApp {
 
   removePrism(prism) {
     this._baseApp.removePrism(prism, this);
+  }
+
+  addListener(eventName, eventHandler) {
+    this._baseApp.addListener(eventName, eventHandler);
+  }
+
+  removeListener(eventName, eventHandler) {
+    this._baseApp.removeListener(eventName, eventHandler);
   }
 }

--- a/src/platform/lumin-runtime/mxs-immersive-app.js
+++ b/src/platform/lumin-runtime/mxs-immersive-app.js
@@ -9,6 +9,13 @@ export class MxsImmersiveApp extends ImmersiveApp {
     this._baseApp = baseApp;
   }
 
+  get OnAppStartData () {
+    return {
+      ...this._baseApp.OnAppStartData, 
+      isImageTrackingReady: typeof this.isImageTrackingReady === 'function' ? this.isImageTrackingReady() : undefined,
+    };
+  }
+
   init() {
     return 0;
   }

--- a/src/platform/lumin-runtime/mxs-landscape-app.js
+++ b/src/platform/lumin-runtime/mxs-landscape-app.js
@@ -21,6 +21,12 @@ export class MxsLandscapeApp extends LandscapeApp {
     this._baseApp.onAppStart(arg);
   }
 
+  addListener(eventName, eventHandler) {
+  }
+
+  removeListener(eventName, eventHandler) {
+  }
+
   updateLoop(delta) {
     return this._baseApp.updateLoop(delta);
   }

--- a/src/platform/lumin-runtime/mxs-landscape-app.js
+++ b/src/platform/lumin-runtime/mxs-landscape-app.js
@@ -21,12 +21,6 @@ export class MxsLandscapeApp extends LandscapeApp {
     this._baseApp.onAppStart(arg);
   }
 
-  addListener(eventName, eventHandler) {
-  }
-
-  removeListener(eventName, eventHandler) {
-  }
-
   updateLoop(delta) {
     return this._baseApp.updateLoop(delta);
   }
@@ -45,5 +39,13 @@ export class MxsLandscapeApp extends LandscapeApp {
 
   removePrism(prism) {
     this._baseApp.removePrism(prism, this);
+  }
+
+  addListener(eventName, eventHandler) {
+    this._baseApp.addListener(eventName, eventHandler);
+  }
+
+  removeListener(eventName, eventHandler) {
+    this._baseApp.removeListener(eventName, eventHandler);
   }
 }

--- a/src/platform/lumin-runtime/mxs-landscape-app.js
+++ b/src/platform/lumin-runtime/mxs-landscape-app.js
@@ -3,11 +3,15 @@
 import { LandscapeApp } from 'lumin';
 
 export class MxsLandscapeApp extends LandscapeApp {
-    constructor(timeDelta, baseApp) {
-        super(timeDelta);
+  constructor(timeDelta, baseApp) {
+    super(timeDelta);
 
-        this._baseApp = baseApp;
-    }
+    this._baseApp = baseApp;
+  }
+
+  get OnAppStartData () {
+    return this._baseApp.OnAppStartData;
+  }
 
   init() {
     return 0;

--- a/src/platform/lumin-runtime/platform-factory.js
+++ b/src/platform/lumin-runtime/platform-factory.js
@@ -198,7 +198,7 @@ export class PlatformFactory extends NativeFactory {
       this.elementBuilders[name] = this._mapping.elements[name]();
     }
 
-    return this.elementBuilders[name].create();
+    return this.elementBuilders[name].create(this._app, ...args);
   }
 
   createElement (name, container, ...args) {

--- a/src/platform/lumin-runtime/platform-factory.js
+++ b/src/platform/lumin-runtime/platform-factory.js
@@ -254,6 +254,7 @@ export class PlatformFactory extends NativeFactory {
     }
 
     if (name === 'scene') {
+      this.elementBuilders[name].update(...args, this._app);
       return;
     }
 


### PR DESCRIPTION
- [x] Your code builds clean without any errors or warnings
- [x] You are using approved terminology
- [ ] You have added unit tests

Added support for `onAppStart`, `onAppPause` and `onAppResume` BaseApp events by using `Scene` component.
```
<Scene
  onAppStart={(data) => console.log(data)}
  onAppPause={() => console.log('onAppPause')}
  onAppResume={() => console.log('onAppResume')}
>
...
</Scene>
```